### PR TITLE
feat: add simple PHP/HTML registration website starter

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -13,6 +13,7 @@ This is the category in which you'll find documentation on how to set things up,
             <li><a href="/docs/guides/getting_started.md">Getting Started</a></li>
             <li><a href="/docs/guides/installing_mysql.md">Installing MySQL Database</a></li>
             <li style="margin-top: 5px"><a href="/docs/guides/glossary.md">Glossary</a></li>
+            <li><a href="/docs/guides/account_registration_website.md">Account Registration Website Guide</a></li>
         </ul>
     </li>
     <li><a href="/docs/contribution">Contribution</a>

--- a/docs/guides/account_registration_website.md
+++ b/docs/guides/account_registration_website.md
@@ -1,0 +1,102 @@
+# Account Registration Website Guide
+
+Deze gids beschrijft wat je nodig hebt om een simpele website te maken waarmee spelers accounts kunnen registreren voor deze Ub3r game-server.
+
+## Wat je al hebt in deze repo
+
+- De server gebruikt een MySQL-database.
+- Login valideert tegen de `user`-tabel.
+- De login-flow gebruikt een salted MD5-hash (`MD5(MD5(password) + salt)`).
+
+## Minimale eisen voor je registratie-website
+
+1. **Web-app runtime**
+   - Kies bijvoorbeeld Node.js (Express/Nest), PHP (Laravel), Python (Django/FastAPI) of Java (Spring Boot).
+
+2. **Database-connectie naar dezelfde MySQL**
+   - Verbind met dezelfde DB als de game-server (host, poort, naam, user, password).
+
+3. **Registratieformulier**
+   - Vereiste velden: username, email, password, password confirmation.
+   - Server-side validatie:
+     - username: 3-12 tekens, alleen letters/cijfers/underscore.
+     - email: geldig formaat.
+     - password: minimale lengte (bijv. 8+).
+
+4. **Password hashing compatibel met game-server**
+   - Genereer een random `salt` (30 chars, zoals DB-schema verwacht).
+   - Maak hash als:
+     - `passM = MD5(plainPassword)`
+     - `password = MD5(passM + salt)`
+   - Sla **beide** op: `password` en `salt`.
+
+5. **Database insert in `user`-tabel**
+   - Minimaal invullen:
+     - `username`
+     - `password`
+     - `salt`
+     - `email`
+     - `passworddate`
+     - `birthday_search`
+   - Laat waar mogelijk defaults van de tabel het werk doen.
+   - Gebruik altijd prepared statements (geen string-concatenatie).
+
+6. **Foutafhandeling en UX**
+   - Toon duidelijke errors bij:
+     - bestaande username
+     - zwak/ongeldig wachtwoord
+     - databasefout
+   - Succesmelding: account aangemaakt, je kunt nu inloggen in-game.
+
+7. **Security (belangrijk)**
+   - HTTPS verplicht.
+   - Rate limiting op registratie endpoint.
+   - CAPTCHA / bot bescherming.
+   - Input sanitization + prepared statements.
+   - Audit logging op registraties (ip, timestamp, username).
+
+## Let op over hashing
+
+Salted MD5 is verouderd voor moderne web-security. Voor compatibiliteit met deze server moet je dit voorlopig volgen. De beste lange-termijnstap is migreren naar een sterkere hash (bijv. Argon2id of bcrypt) in zowel game-server als webregistratie-flow.
+
+## Aanbevolen API-contract (voorbeeld)
+
+`POST /api/register`
+
+Request:
+
+```json
+{
+  "username": "Player123",
+  "email": "player@example.com",
+  "password": "SuperSecret123",
+  "confirmPassword": "SuperSecret123"
+}
+```
+
+Response success:
+
+```json
+{
+  "ok": true,
+  "message": "Account created"
+}
+```
+
+Response error:
+
+```json
+{
+  "ok": false,
+  "message": "Username already exists"
+}
+```
+
+## Checklist om live te gaan
+
+- [ ] DNS + domein
+- [ ] HTTPS-certificaat
+- [ ] Productie database credentials in secrets manager
+- [ ] Dagelijkse database backups
+- [ ] Monitoring + alerting op foutpercentages
+- [ ] Basis abuse protectie (rate-limit + captcha)

--- a/docs/guides/account_registration_website.md
+++ b/docs/guides/account_registration_website.md
@@ -1,65 +1,65 @@
 # Account Registration Website Guide
 
-Deze gids beschrijft wat je nodig hebt om een simpele website te maken waarmee spelers accounts kunnen registreren voor deze Ub3r game-server.
+This guide explains what you need to build a simple website that lets players register accounts for this Ub3r game server.
 
-## Wat je al hebt in deze repo
+## What you already have in this repository
 
-- De server gebruikt een MySQL-database.
-- Login valideert tegen de `user`-tabel.
-- De login-flow gebruikt een salted MD5-hash (`MD5(MD5(password) + salt)`).
+- The server uses a MySQL database.
+- Login validation checks the `user` table.
+- The login flow uses a salted MD5 hash (`MD5(MD5(password) + salt)`).
 
-## Minimale eisen voor je registratie-website
+## Minimum requirements for your registration website
 
-1. **Web-app runtime**
-   - Kies bijvoorbeeld Node.js (Express/Nest), PHP (Laravel), Python (Django/FastAPI) of Java (Spring Boot).
+1. **Web app runtime**
+   - Use something like Node.js (Express/Nest), PHP (Laravel/plain PHP), Python (Django/FastAPI), or Java (Spring Boot).
 
-2. **Database-connectie naar dezelfde MySQL**
-   - Verbind met dezelfde DB als de game-server (host, poort, naam, user, password).
+2. **Database connection to the same MySQL instance**
+   - Connect to the same DB as the game server (host, port, name, user, password).
 
-3. **Registratieformulier**
-   - Vereiste velden: username, email, password, password confirmation.
-   - Server-side validatie:
-     - username: 3-12 tekens, alleen letters/cijfers/underscore.
-     - email: geldig formaat.
-     - password: minimale lengte (bijv. 8+).
+3. **Registration form**
+   - Required fields: username, email, password, password confirmation.
+   - Server-side validation:
+     - username: 3-12 chars, letters/numbers/underscore only.
+     - email: valid email format.
+     - password: minimum length (for example 8+).
 
-4. **Password hashing compatibel met game-server**
-   - Genereer een random `salt` (30 chars, zoals DB-schema verwacht).
-   - Maak hash als:
+4. **Password hashing compatible with the game server**
+   - Generate a random `salt` (30 chars, matching the DB schema).
+   - Build hash as:
      - `passM = MD5(plainPassword)`
      - `password = MD5(passM + salt)`
-   - Sla **beide** op: `password` en `salt`.
+   - Store **both** values: `password` and `salt`.
 
-5. **Database insert in `user`-tabel**
-   - Minimaal invullen:
+5. **Database insert into `user` table**
+   - Minimum fields to populate:
      - `username`
      - `password`
      - `salt`
      - `email`
      - `passworddate`
      - `birthday_search`
-   - Laat waar mogelijk defaults van de tabel het werk doen.
-   - Gebruik altijd prepared statements (geen string-concatenatie).
+   - Let table defaults handle the rest when possible.
+   - Always use prepared statements (no SQL string concatenation).
 
-6. **Foutafhandeling en UX**
-   - Toon duidelijke errors bij:
-     - bestaande username
-     - zwak/ongeldig wachtwoord
-     - databasefout
-   - Succesmelding: account aangemaakt, je kunt nu inloggen in-game.
+6. **Error handling and UX**
+   - Show clear errors for:
+     - existing username
+     - weak/invalid password
+     - database error
+   - Success message example: account created, you can now log in in-game.
 
-7. **Security (belangrijk)**
-   - HTTPS verplicht.
-   - Rate limiting op registratie endpoint.
-   - CAPTCHA / bot bescherming.
+7. **Security (important)**
+   - HTTPS required.
+   - Rate limiting on registration endpoint.
+   - CAPTCHA / bot protection.
    - Input sanitization + prepared statements.
-   - Audit logging op registraties (ip, timestamp, username).
+   - Audit logging for registrations (IP, timestamp, username).
 
-## Let op over hashing
+## Important note on hashing
 
-Salted MD5 is verouderd voor moderne web-security. Voor compatibiliteit met deze server moet je dit voorlopig volgen. De beste lange-termijnstap is migreren naar een sterkere hash (bijv. Argon2id of bcrypt) in zowel game-server als webregistratie-flow.
+Salted MD5 is outdated for modern web security. You need it for compatibility with this server today. The best long-term improvement is migrating to a stronger hash (for example Argon2id or bcrypt) in both the game server and registration flow.
 
-## Aanbevolen API-contract (voorbeeld)
+## Recommended API contract (example)
 
 `POST /api/register`
 
@@ -74,7 +74,7 @@ Request:
 }
 ```
 
-Response success:
+Success response:
 
 ```json
 {
@@ -83,7 +83,7 @@ Response success:
 }
 ```
 
-Response error:
+Error response:
 
 ```json
 {
@@ -92,11 +92,11 @@ Response error:
 }
 ```
 
-## Checklist om live te gaan
+## Go-live checklist
 
-- [ ] DNS + domein
-- [ ] HTTPS-certificaat
-- [ ] Productie database credentials in secrets manager
-- [ ] Dagelijkse database backups
-- [ ] Monitoring + alerting op foutpercentages
-- [ ] Basis abuse protectie (rate-limit + captcha)
+- [ ] DNS + domain
+- [ ] HTTPS certificate
+- [ ] Production DB credentials stored in a secrets manager
+- [ ] Daily database backups
+- [ ] Monitoring + alerting for error rates
+- [ ] Basic abuse protection (rate limit + CAPTCHA)

--- a/web-registration-simple/.gitignore
+++ b/web-registration-simple/.gitignore
@@ -1,0 +1,1 @@
+config.php

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -1,12 +1,12 @@
 # Simple PHP Registration Website
 
-Een minimale registratiepagina in PHP + HTML, compatibel met de huidige Ub3r password-hash flow.
+A minimal PHP + HTML registration page compatible with the current Ub3r password-hash flow.
 
-## Starten
+## Getting started
 
-1. Kopieer `config.example.php` naar `config.php`.
-2. Vul je databasegegevens in.
-3. Start lokaal:
+1. Copy `config.example.php` to `config.php`.
+2. Fill in your database credentials.
+3. Start locally:
 
 ```bash
 php -S 0.0.0.0:8080 -t web-registration-simple
@@ -14,15 +14,15 @@ php -S 0.0.0.0:8080 -t web-registration-simple
 
 4. Open `http://localhost:8080`.
 
-## Compatibele password hash
+## Compatible password hash
 
-Deze demo gebruikt dezelfde flow als de game-server:
+This demo uses the same flow as the game server:
 
 - `passM = md5(password)`
 - `stored = md5(passM + salt)`
 
-## Veiligheidsnotities
+## Security notes
 
-- Gebruik HTTPS in productie.
-- Voeg rate limiting en captcha toe.
-- Sla `config.php` nooit in git op.
+- Use HTTPS in production.
+- Add rate limiting and CAPTCHA.
+- Never commit `config.php` to git.

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -1,0 +1,28 @@
+# Simple PHP Registration Website
+
+Een minimale registratiepagina in PHP + HTML, compatibel met de huidige Ub3r password-hash flow.
+
+## Starten
+
+1. Kopieer `config.example.php` naar `config.php`.
+2. Vul je databasegegevens in.
+3. Start lokaal:
+
+```bash
+php -S 0.0.0.0:8080 -t web-registration-simple
+```
+
+4. Open `http://localhost:8080`.
+
+## Compatibele password hash
+
+Deze demo gebruikt dezelfde flow als de game-server:
+
+- `passM = md5(password)`
+- `stored = md5(passM + salt)`
+
+## Veiligheidsnotities
+
+- Gebruik HTTPS in productie.
+- Voeg rate limiting en captcha toe.
+- Sla `config.php` nooit in git op.

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'db' => [
+        'host' => '127.0.0.1',
+        'port' => 3306,
+        'name' => 'dodiannet',
+        'user' => 'dodian_game',
+        'password' => 'abcd1234',
+        'charset' => 'utf8mb4',
+    ],
+];

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+$configPath = __DIR__ . '/config.php';
+$configMissing = !file_exists($configPath);
+$config = $configMissing ? null : require $configPath;
+
+function randomSalt(int $length = 30): string
+{
+    $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    $alphabetLen = strlen($alphabet);
+    $salt = '';
+
+    for ($i = 0; $i < $length; $i++) {
+        $salt .= $alphabet[random_int(0, $alphabetLen - 1)];
+    }
+
+    return $salt;
+}
+
+function dodianPasswordHash(string $password, string $salt): string
+{
+    $passM = md5($password);
+    return md5($passM . $salt);
+}
+
+function pdoFromConfig(array $config): PDO
+{
+    $db = $config['db'];
+    $dsn = sprintf('mysql:host=%s;port=%d;dbname=%s;charset=%s', $db['host'], $db['port'], $db['name'], $db['charset']);
+
+    return new PDO($dsn, $db['user'], $db['password'], [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+}
+
+$errors = [];
+$successMessage = null;
+$username = '';
+$email = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if ($configMissing) {
+        $errors[] = 'Server is nog niet geconfigureerd. Kopieer config.example.php naar config.php en vul DB-gegevens in.';
+    }
+
+    $username = trim((string)($_POST['username'] ?? ''));
+    $email = trim((string)($_POST['email'] ?? ''));
+    $password = (string)($_POST['password'] ?? '');
+    $confirmPassword = (string)($_POST['confirm_password'] ?? '');
+
+    if (!preg_match('/^[A-Za-z0-9_]{3,12}$/', $username)) {
+        $errors[] = 'Username moet 3-12 tekens zijn en alleen letters, cijfers of underscore bevatten.';
+    }
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Voer een geldig e-mailadres in.';
+    }
+
+    if (strlen($password) < 8) {
+        $errors[] = 'Wachtwoord moet minimaal 8 tekens bevatten.';
+    }
+
+    if ($password !== $confirmPassword) {
+        $errors[] = 'Wachtwoorden komen niet overeen.';
+    }
+
+    if (!$configMissing && empty($errors)) {
+        try {
+            $pdo = pdoFromConfig($config);
+
+            $stmt = $pdo->prepare('SELECT 1 FROM user WHERE username = :username LIMIT 1');
+            $stmt->execute(['username' => $username]);
+            if ($stmt->fetch()) {
+                $errors[] = 'Deze username bestaat al.';
+            } else {
+                $salt = randomSalt(30);
+                $storedPassword = dodianPasswordHash($password, $salt);
+
+                $insert = $pdo->prepare(
+                    'INSERT INTO user (username, password, salt, email, passworddate, birthday_search, joindate)
+                     VALUES (:username, :password, :salt, :email, :passworddate, :birthday_search, :joindate)'
+                );
+
+                $insert->execute([
+                    'username' => $username,
+                    'password' => $storedPassword,
+                    'salt' => $salt,
+                    'email' => $email,
+                    'passworddate' => date('Y-m-d H:i:s'),
+                    'birthday_search' => '',
+                    'joindate' => time(),
+                ]);
+
+                $successMessage = 'Account aangemaakt! Je kunt nu inloggen in-game.';
+                $username = '';
+                $email = '';
+            }
+        } catch (Throwable $e) {
+            $errors[] = 'Registratie mislukt door een server/database fout.';
+            error_log('Registration error: ' . $e->getMessage());
+        }
+    }
+}
+?>
+<!doctype html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dodian Account Registratie</title>
+    <style>
+        :root { color-scheme: dark; }
+        body {
+            margin: 0;
+            font-family: Inter, system-ui, Arial, sans-serif;
+            background: #0f172a;
+            color: #e2e8f0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            padding: 24px;
+        }
+        .card {
+            width: 100%;
+            max-width: 460px;
+            background: #111827;
+            border: 1px solid #1f2937;
+            border-radius: 12px;
+            padding: 24px;
+            box-shadow: 0 10px 30px rgba(0,0,0,.35);
+        }
+        h1 { margin-top: 0; font-size: 1.4rem; }
+        p.meta { color: #94a3b8; font-size: 0.95rem; }
+        label { display: block; margin: 14px 0 6px; font-weight: 600; }
+        input {
+            width: 100%;
+            padding: 10px 12px;
+            border-radius: 8px;
+            border: 1px solid #334155;
+            background: #0b1220;
+            color: #e2e8f0;
+            box-sizing: border-box;
+        }
+        button {
+            margin-top: 18px;
+            width: 100%;
+            padding: 11px 14px;
+            border: 0;
+            border-radius: 8px;
+            background: #22c55e;
+            color: #06220f;
+            font-weight: 700;
+            cursor: pointer;
+        }
+        .errors, .success {
+            margin: 12px 0;
+            padding: 10px 12px;
+            border-radius: 8px;
+            font-size: 0.95rem;
+        }
+        .errors { background: #7f1d1d; color: #fecaca; }
+        .success { background: #14532d; color: #bbf7d0; }
+        ul { margin: 0; padding-left: 20px; }
+    </style>
+</head>
+<body>
+<div class="card">
+    <h1>Dodian registratie</h1>
+    <p class="meta">Maak je account aan om in te loggen op de game-server.</p>
+
+    <?php if ($configMissing): ?>
+        <div class="errors">
+            Config ontbreekt: kopieer <code>config.example.php</code> naar <code>config.php</code> voordat registraties worden opgeslagen.
+        </div>
+    <?php endif; ?>
+
+    <?php if (!empty($errors)): ?>
+        <div class="errors">
+            <ul>
+                <?php foreach ($errors as $error): ?>
+                    <li><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($successMessage !== null): ?>
+        <div class="success"><?= htmlspecialchars($successMessage, ENT_QUOTES, 'UTF-8') ?></div>
+    <?php endif; ?>
+
+    <form method="post" action="">
+        <label for="username">Username</label>
+        <input id="username" name="username" maxlength="12" required value="<?= htmlspecialchars($username, ENT_QUOTES, 'UTF-8') ?>">
+
+        <label for="email">E-mail</label>
+        <input id="email" name="email" type="email" required value="<?= htmlspecialchars($email, ENT_QUOTES, 'UTF-8') ?>">
+
+        <label for="password">Wachtwoord</label>
+        <input id="password" name="password" type="password" minlength="8" required>
+
+        <label for="confirm_password">Herhaal wachtwoord</label>
+        <input id="confirm_password" name="confirm_password" type="password" minlength="8" required>
+
+        <button type="submit">Account aanmaken</button>
+    </form>
+</div>
+</body>
+</html>

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -43,7 +43,7 @@ $email = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($configMissing) {
-        $errors[] = 'Server is nog niet geconfigureerd. Kopieer config.example.php naar config.php en vul DB-gegevens in.';
+        $errors[] = 'Server is not configured yet. Copy config.example.php to config.php and add database credentials.';
     }
 
     $username = trim((string)($_POST['username'] ?? ''));
@@ -52,19 +52,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $confirmPassword = (string)($_POST['confirm_password'] ?? '');
 
     if (!preg_match('/^[A-Za-z0-9_]{3,12}$/', $username)) {
-        $errors[] = 'Username moet 3-12 tekens zijn en alleen letters, cijfers of underscore bevatten.';
+        $errors[] = 'Username must be 3-12 characters and contain only letters, numbers, or underscore.';
     }
 
     if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-        $errors[] = 'Voer een geldig e-mailadres in.';
+        $errors[] = 'Enter a valid email address.';
     }
 
     if (strlen($password) < 8) {
-        $errors[] = 'Wachtwoord moet minimaal 8 tekens bevatten.';
+        $errors[] = 'Password must be at least 8 characters long.';
     }
 
     if ($password !== $confirmPassword) {
-        $errors[] = 'Wachtwoorden komen niet overeen.';
+        $errors[] = 'Passwords do not match.';
     }
 
     if (!$configMissing && empty($errors)) {
@@ -74,7 +74,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $stmt = $pdo->prepare('SELECT 1 FROM user WHERE username = :username LIMIT 1');
             $stmt->execute(['username' => $username]);
             if ($stmt->fetch()) {
-                $errors[] = 'Deze username bestaat al.';
+                $errors[] = 'This username already exists.';
             } else {
                 $salt = randomSalt(30);
                 $storedPassword = dodianPasswordHash($password, $salt);
@@ -94,23 +94,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'joindate' => time(),
                 ]);
 
-                $successMessage = 'Account aangemaakt! Je kunt nu inloggen in-game.';
+                $successMessage = 'Account created! You can now log in in-game.';
                 $username = '';
                 $email = '';
             }
         } catch (Throwable $e) {
-            $errors[] = 'Registratie mislukt door een server/database fout.';
+            $errors[] = 'Registration failed due to a server/database error.';
             error_log('Registration error: ' . $e->getMessage());
         }
     }
 }
 ?>
 <!doctype html>
-<html lang="nl">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dodian Account Registratie</title>
+    <title>Dodian Account Registration</title>
     <style>
         :root { color-scheme: dark; }
         body {
@@ -168,12 +168,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </head>
 <body>
 <div class="card">
-    <h1>Dodian registratie</h1>
-    <p class="meta">Maak je account aan om in te loggen op de game-server.</p>
+    <h1>Dodian registration</h1>
+    <p class="meta">Create your account to log in to the game server.</p>
 
     <?php if ($configMissing): ?>
         <div class="errors">
-            Config ontbreekt: kopieer <code>config.example.php</code> naar <code>config.php</code> voordat registraties worden opgeslagen.
+            Config is missing: copy <code>config.example.php</code> to <code>config.php</code> before registrations can be saved.
         </div>
     <?php endif; ?>
 
@@ -198,13 +198,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <label for="email">E-mail</label>
         <input id="email" name="email" type="email" required value="<?= htmlspecialchars($email, ENT_QUOTES, 'UTF-8') ?>">
 
-        <label for="password">Wachtwoord</label>
+        <label for="password">Password</label>
         <input id="password" name="password" type="password" minlength="8" required>
 
-        <label for="confirm_password">Herhaal wachtwoord</label>
+        <label for="confirm_password">Repeat password</label>
         <input id="confirm_password" name="confirm_password" type="password" minlength="8" required>
 
-        <button type="submit">Account aanmaken</button>
+        <button type="submit">Create account</button>
     </form>
 </div>
 </body>


### PR DESCRIPTION
### Motivation
- Provide a minimal, repo-local PHP + HTML registration starter so developers can spin up a web flow compatible with the Ub3r game-server's user schema and hashing.
- Offer a straightforward example that demonstrates server-side validation, prepared-statement DB writes and the game-compatible salted MD5 hashing for immediate integration and testing.

### Description
- Added a runnable `web-registration-simple/` directory containing `index.php` (registration form + server-side logic), `config.example.php`, `README.md` and `.gitignore` to prevent committing `config.php`.
- Implemented validation for username, email, password length and confirmation, and a clear UI for error and success messages in `index.php`.
- Implemented DB interaction using PDO prepared statements writing into the `user` table and a `dodianPasswordHash` helper implementing `md5(md5(password) + salt)` with a per-user 30-char random salt.
- Show a warning state if `config.php` is missing and document startup steps and security notes in `web-registration-simple/README.md`.

### Testing
- Ran PHP lint checks: `php -l web-registration-simple/index.php` and `php -l web-registration-simple/config.example.php`, both succeeded.
- Ran repository format checks with `git diff --check`, which returned no issues.
- Performed a local smoke test by launching the built-in PHP server and curling the root: `php -S 127.0.0.1:8081 -t web-registration-simple` and `curl` returned HTTP 200.
- Captured a browser screenshot of the served page with an automated Playwright script for visual verification, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996043fb118832996fc0e7f4e6331ce)