### PR TITLE
Add web account portal with login, activation gating, and password recovery

### DIFF
--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -8,6 +8,8 @@ A minimal PHP + HTML account portal with registration, login, downloads, activat
 2. Fill in your database credentials.
 3. Configure these required activation settings in `config.php`:
    - `app.base_url` (public URL of the registration page)
+   - `app.client_jar_url` (direct link to your single game client `.jar`)
+   - `app.java_download_url` (Java download page, defaults to java.com)
    - `brevo.api_key`
    - `brevo.sender_email`
    - `turnstile.site_key`
@@ -35,7 +37,7 @@ This demo uses the same flow as the game server:
 - Clicking the link changes the account to `usergroupid = 40` (active), which is required for login.
 - Expired activation links auto-ban the account (`usergroupid = 8`).
 - Registration blocks duplicate usernames and duplicate email addresses.
-- Successful login redirects users to `?page=download`.
+- Successful login redirects users to `?page=download` with one game client `.jar` download button and one Java download button.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 
 ## Security notes

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -10,6 +10,7 @@ A minimal PHP + HTML account portal with registration, login, downloads, activat
    - `app.base_url` (public URL of the registration page)
    - `app.client_jar_url` (direct link to your single game client `.jar`)
    - `app.java_download_url` (Java download page, defaults to java.com)
+   - `app.discord_url` (invite link for your Discord community)
    - `brevo.api_key`
    - `brevo.sender_email`
    - `turnstile.site_key`
@@ -37,7 +38,7 @@ This demo uses the same flow as the game server:
 - Clicking the link changes the account to `usergroupid = 40` (active), which is required for login.
 - Expired activation links auto-ban the account (`usergroupid = 8`).
 - Registration blocks duplicate usernames and duplicate email addresses.
-- Successful login redirects users to `?page=download` with one game client `.jar` download button and one Java download button.
+- Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and one Discord button.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 
 ## Security notes

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -1,6 +1,6 @@
-# Simple PHP Registration Website
+# Simple PHP Account Website
 
-A minimal PHP + HTML registration page compatible with the current Ub3r password-hash flow.
+A minimal PHP + HTML account portal with registration, login, downloads, activation, and forgot-password flows compatible with the current Ub3r password-hash flow.
 
 ## Getting started
 
@@ -27,14 +27,16 @@ This demo uses the same flow as the game server:
 - `passM = md5(password)`
 - `stored = md5(passM + salt)`
 
-## Account activation and email uniqueness
+## Account activation, login, and password recovery
 
 - Registrations start as `usergroupid = 3` (inactive).
 - An activation token is stored in `user_activation_tokens`.
-- Brevo sends an activation email with a link (`/?token=...`) that is valid for 2 hours.
-- Clicking the link changes the account to `usergroupid = 40` (active).
+- Brevo sends an activation email with a link (`/?page=activate&token=...`) that is valid for 2 hours.
+- Clicking the link changes the account to `usergroupid = 40` (active), which is required for login.
 - Expired activation links auto-ban the account (`usergroupid = 8`).
 - Registration blocks duplicate usernames and duplicate email addresses.
+- Successful login redirects users to `?page=download`.
+- Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 
 ## Security notes
 

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -1,6 +1,6 @@
 # Simple PHP Account Website
 
-A minimal PHP + HTML account portal with registration, login, downloads, activation, and forgot-password flows compatible with the current Ub3r password-hash flow.
+A minimal PHP + HTML account portal with registration, login, downloads, activation, forgot-password, and in-session change-password flows compatible with the current Ub3r password-hash flow.
 
 ## Getting started
 
@@ -40,6 +40,7 @@ This demo uses the same flow as the game server:
 - Registration blocks duplicate usernames and duplicate email addresses.
 - Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and one Discord button.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
+- Signed-in users can change their password from `?page=change-password` by confirming their current password.
 
 ## Security notes
 

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -15,6 +15,7 @@ return [
         'base_url' => 'http://localhost:8080',
         'client_jar_url' => 'https://example.com/downloads/dodian-client.jar',
         'java_download_url' => 'https://www.java.com/download/',
+        'discord_url' => 'https://discord.gg/your-server',
     ],
     'brevo' => [
         'api_key' => 'xkeysib-REPLACE_ME',

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -13,6 +13,8 @@ return [
     ],
     'app' => [
         'base_url' => 'http://localhost:8080',
+        'client_jar_url' => 'https://example.com/downloads/dodian-client.jar',
+        'java_download_url' => 'https://www.java.com/download/',
     ],
     'brevo' => [
         'api_key' => 'xkeysib-REPLACE_ME',

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -769,6 +769,11 @@ $resetTokenFromQuery = isset($_GET['token']) && is_string($_GET['token']) ? trim
             color: #e2e8f0;
             margin-top: 10px;
         }
+        .btn-link.discord {
+            background: #5865f2;
+            color: #ffffff;
+            margin-top: 10px;
+        }
         .errors, .success, .info {
             margin: 12px 0;
             padding: 10px 12px;
@@ -903,9 +908,9 @@ $resetTokenFromQuery = isset($_GET['token']) && is_string($_GET['token']) ? trim
     <?php if ($page === 'download'): ?>
         <p class="meta">Welcome, <?= htmlspecialchars((string)($_SESSION['username'] ?? 'Player'), ENT_QUOTES, 'UTF-8') ?>. You are signed in.</p>
         <div class="downloads">
-            <a class="btn-link" href="<?= htmlspecialchars($clientJarUrl, ENT_QUOTES, 'UTF-8') ?>">Download game client (.jar)</a>
+            <a class="btn-link" href="<?= htmlspecialchars($clientJarUrl, ENT_QUOTES, 'UTF-8') ?>">Download game client</a>
             <a class="btn-link secondary" href="<?= htmlspecialchars($javaDownloadUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Download Java</a>
-            <a class="btn-link secondary" href="<?= htmlspecialchars($discordUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Join Discord</a>
+            <a class="btn-link discord" href="<?= htmlspecialchars($discordUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Join Discord</a>
             <a class="btn-link secondary" href="?page=change-password">Change password</a>
             <a class="btn-link secondary" href="?logout=1">Sign out</a>
         </div>

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -230,6 +230,7 @@ $infoMessage = null;
 $turnstileSiteKey = $configMissing ? '' : trim((string)($config['turnstile']['site_key'] ?? ''));
 $clientJarUrl = $configMissing ? '#' : trim((string)($config['app']['client_jar_url'] ?? '#'));
 $javaDownloadUrl = $configMissing ? 'https://www.java.com/download/' : trim((string)($config['app']['java_download_url'] ?? 'https://www.java.com/download/'));
+$discordUrl = $configMissing ? 'https://discord.gg/' : trim((string)($config['app']['discord_url'] ?? 'https://discord.gg/'));
 
 $page = isset($_GET['page']) && is_string($_GET['page']) ? strtolower(trim($_GET['page'])) : '';
 $allowedPages = ['login', 'register', 'forgot-password', 'download', 'reset-password', 'activate'];
@@ -829,6 +830,7 @@ $resetTokenFromQuery = isset($_GET['token']) && is_string($_GET['token']) ? trim
         <div class="downloads">
             <a class="btn-link" href="<?= htmlspecialchars($clientJarUrl, ENT_QUOTES, 'UTF-8') ?>">Download game client (.jar)</a>
             <a class="btn-link secondary" href="<?= htmlspecialchars($javaDownloadUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Download Java</a>
+            <a class="btn-link secondary" href="<?= htmlspecialchars($discordUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Join Discord</a>
             <a class="btn-link secondary" href="?logout=1">Sign out</a>
         </div>
     <?php endif; ?>

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -228,6 +228,8 @@ $errors = [];
 $successMessage = null;
 $infoMessage = null;
 $turnstileSiteKey = $configMissing ? '' : trim((string)($config['turnstile']['site_key'] ?? ''));
+$clientJarUrl = $configMissing ? '#' : trim((string)($config['app']['client_jar_url'] ?? '#'));
+$javaDownloadUrl = $configMissing ? 'https://www.java.com/download/' : trim((string)($config['app']['java_download_url'] ?? 'https://www.java.com/download/'));
 
 $page = isset($_GET['page']) && is_string($_GET['page']) ? strtolower(trim($_GET['page'])) : '';
 $allowedPages = ['login', 'register', 'forgot-password', 'download', 'reset-password', 'activate'];
@@ -825,9 +827,8 @@ $resetTokenFromQuery = isset($_GET['token']) && is_string($_GET['token']) ? trim
     <?php if ($page === 'download'): ?>
         <p class="meta">Welcome, <?= htmlspecialchars((string)($_SESSION['username'] ?? 'Player'), ENT_QUOTES, 'UTF-8') ?>. You are signed in.</p>
         <div class="downloads">
-            <a class="btn-link" href="#">Download Windows client</a>
-            <a class="btn-link secondary" href="#">Download Mac client</a>
-            <a class="btn-link secondary" href="#">Download Linux client</a>
+            <a class="btn-link" href="<?= htmlspecialchars($clientJarUrl, ENT_QUOTES, 'UTF-8') ?>">Download game client (.jar)</a>
+            <a class="btn-link secondary" href="<?= htmlspecialchars($javaDownloadUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Download Java</a>
             <a class="btn-link secondary" href="?logout=1">Sign out</a>
         </div>
     <?php endif; ?>


### PR DESCRIPTION
### Motivation

- Replace the single registration page with a small account portal so users can register, sign in, activate accounts, request password resets and access a downloads page after signing in.
- Enforce that only activated accounts (game `usergroupid = 40`) may sign in and be given access to downloads.
- Provide a server-side password-reset flow with expiring tokens and email delivery so users can recover access.
- Keep the existing dark styling and make all web pages English-only.

### Description

- Reworked `web-registration-simple/index.php` into a single page account portal with route-based pages: `?page=login`, `?page=register`, `?page=forgot-password`, `?page=reset-password`, `?page=activate`, and `?page=download` while preserving the original visual style.
- Added session-based login, activation check (only `usergroupid = 40` allowed), and redirect on successful login to `?page=download`.
- Implemented password-reset support: `ensurePasswordResetTable()` creates `user_password_reset_tokens`, `forgot-password` generates a reset token and emails a `?page=reset-password&token=...` link, and `reset-password` validates the token and updates the stored password using the existing Dodian hash flow.
- Generalized Brevo email sending to `sendBrevoEmail()`, added `buildAppUrl()`, `requireConfiguredOrFail()` and `redirectTo()` helpers, and adapted account activation links to `?page=activate&token=...`.
- Updated `web-registration-simple/README.md` to document the portal, activation gating, download redirect, and password recovery flow.

### Testing

- Ran syntax checks with `php -l web-registration-simple/index.php` and `php -l web-registration-simple/config.example.php`; both reported no syntax errors.
- Started the built-in PHP server with `php -S 0.0.0.0:8080 -t web-registration-simple` and confirmed it served requests successfully.
- Performed a visual verification capture of the login page using a Playwright script which completed and produced a screenshot of `/?page=login`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996325b49248329a4c97cde8c98dde4)