### PR TITLE
Store and display Discord display names for linked accounts

### DIFF
--- a/web-registration-simple/DiscordRoleManager.php
+++ b/web-registration-simple/DiscordRoleManager.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+final class DiscordRoleManager
+{
+    private string $botToken;
+    private string $guildId;
+    private string $verifiedRoleId;
+
+    public function __construct(string $botToken, string $guildId, string $verifiedRoleId)
+    {
+        $this->botToken = trim($botToken);
+        $this->guildId = trim($guildId);
+        $this->verifiedRoleId = trim($verifiedRoleId);
+
+        if ($this->botToken === '' || $this->guildId === '' || $this->verifiedRoleId === '') {
+            throw new RuntimeException('Discord role manager is missing bot_token, guild_id, or verified_role_id.');
+        }
+    }
+
+    public function assignVerifiedRole(string $discordUserId, string $userAccessToken): void
+    {
+        $discordUserId = trim($discordUserId);
+        $userAccessToken = trim($userAccessToken);
+
+        if ($discordUserId === '' || $userAccessToken === '') {
+            throw new RuntimeException('Discord user id or access token is missing.');
+        }
+
+        $this->discordRequest(
+            'PUT',
+            sprintf('/guilds/%s/members/%s', rawurlencode($this->guildId), rawurlencode($discordUserId)),
+            [
+                'Authorization: Bot ' . $this->botToken,
+                'Content-Type: application/json',
+            ],
+            [
+                'access_token' => $userAccessToken,
+            ],
+            [201, 204]
+        );
+
+        $this->discordRequest(
+            'PUT',
+            sprintf(
+                '/guilds/%s/members/%s/roles/%s',
+                rawurlencode($this->guildId),
+                rawurlencode($discordUserId),
+                rawurlencode($this->verifiedRoleId)
+            ),
+            [
+                'Authorization: Bot ' . $this->botToken,
+            ],
+            null,
+            [204]
+        );
+    }
+
+    private function discordRequest(string $method, string $path, array $headers, ?array $jsonPayload, array $expectedStatuses): array
+    {
+        $ch = curl_init('https://discord.com/api/v10' . $path);
+        if ($ch === false) {
+            throw new RuntimeException('Failed to initialize Discord API request.');
+        }
+
+        $options = [
+            CURLOPT_CUSTOMREQUEST => $method,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_TIMEOUT => 15,
+        ];
+
+        if ($jsonPayload !== null) {
+            $options[CURLOPT_POSTFIELDS] = json_encode($jsonPayload, JSON_THROW_ON_ERROR);
+        }
+
+        curl_setopt_array($ch, $options);
+
+        $response = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        $error = curl_error($ch);
+        curl_close($ch);
+
+        if ($response === false) {
+            throw new RuntimeException('Discord API request failed: ' . $error);
+        }
+
+        if (!in_array($status, $expectedStatuses, true)) {
+            throw new RuntimeException(sprintf('Discord API returned HTTP %d: %s', $status, $response));
+        }
+
+        $decoded = json_decode($response, true);
+        return is_array($decoded) ? $decoded : [];
+    }
+}

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -16,6 +16,7 @@ A minimal PHP + HTML account portal with registration, login, downloads, activat
    - `discord.client_id`
    - `discord.client_secret`
    - `discord.redirect_uri`
+   - `discord.oauth_scopes` (default `identify guilds.join`)
    - `discord.guild_id`
    - `discord.verified_role_id`
    - `discord.bot_token`
@@ -56,3 +57,12 @@ This demo uses the same flow as the game server:
 - Cloudflare Turnstile is integrated and validated server-side for each registration.
 - Add rate limiting as a second layer.
 - Never commit `config.php` to git.
+
+
+## Discord OAuth troubleshooting
+
+If Discord shows **Invalid OAuth2 redirect_uri** while linking:
+
+- Ensure `discord.redirect_uri` in `config.php` is **exactly** the same as your Discord app Redirect URL (including protocol, host, trailing slash, and query string).
+- Add the exact same URL under **Discord Developer Portal → OAuth2 → Redirects**.
+- Default scopes are `identify guilds.join`; you can override via `discord.oauth_scopes`.

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -1,6 +1,6 @@
 # Simple PHP Account Website
 
-A minimal PHP + HTML account portal with registration, login, downloads, activation, forgot-password, and in-session change-password flows compatible with the current Ub3r password-hash flow.
+A minimal PHP + HTML account portal with registration, login, downloads, activation, forgot-password, in-session change-password flows, and Discord account linking with verified-role assignment compatible with the current Ub3r password-hash flow.
 
 ## Getting started
 
@@ -13,6 +13,12 @@ A minimal PHP + HTML account portal with registration, login, downloads, activat
    - `app.discord_url` (invite link for your Discord community)
    - `brevo.api_key`
    - `brevo.sender_email`
+   - `discord.client_id`
+   - `discord.client_secret`
+   - `discord.redirect_uri`
+   - `discord.guild_id`
+   - `discord.verified_role_id`
+   - `discord.bot_token`
    - `turnstile.site_key`
    - `turnstile.secret_key`
 4. Start locally:
@@ -38,7 +44,9 @@ This demo uses the same flow as the game server:
 - Clicking the link changes the account to `usergroupid = 40` (active), which is required for login.
 - Expired activation links auto-ban the account (`usergroupid = 8`).
 - Registration blocks duplicate usernames and duplicate email addresses.
-- Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and one Discord button.
+- Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and Discord actions.
+- Users can link Discord through `?page=discord-link` (OAuth2 `identify guilds.join`) and the site stores links in `user_discord_links`, including Discord username and Discord display name.
+- The new `DiscordRoleManager` module assigns/refreshes the verified Discord role using the configured bot token.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 - Signed-in users can change their password from `?page=change-password` by confirming their current password.
 

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -27,6 +27,7 @@ return [
         'client_id' => '123456789012345678',
         'client_secret' => 'REPLACE_ME',
         'redirect_uri' => 'http://localhost:8080/?page=discord-callback',
+        'oauth_scopes' => 'identify guilds.join',
         'guild_id' => '123456789012345678',
         'verified_role_id' => '123456789012345678',
         'bot_token' => 'REPLACE_ME',

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -22,6 +22,15 @@ return [
         'sender_email' => 'noreply@example.com',
         'sender_name' => 'Dodian',
     ],
+
+    'discord' => [
+        'client_id' => '123456789012345678',
+        'client_secret' => 'REPLACE_ME',
+        'redirect_uri' => 'http://localhost:8080/?page=discord-callback',
+        'guild_id' => '123456789012345678',
+        'verified_role_id' => '123456789012345678',
+        'bot_token' => 'REPLACE_ME',
+    ],
     'turnstile' => [
         'site_key' => '0x4AAAAA-REPLACE_ME',
         'secret_key' => '0x4AAAAA-REPLACE_ME',

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 session_start();
 
+require_once __DIR__ . '/DiscordRoleManager.php';
+
 const INACTIVE_USERGROUP_ID = 3;
 const ACTIVE_USERGROUP_ID = 40;
 const BANNED_USERGROUP_ID = 8;
@@ -125,6 +127,148 @@ function ensurePasswordResetTable(PDO $pdo): void
     );
 }
 
+function ensureDiscordLinksTable(PDO $pdo): void
+{
+    $pdo->exec(
+        'CREATE TABLE IF NOT EXISTS user_discord_links (
+            id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            user_id INT UNSIGNED NOT NULL,
+            discord_user_id VARCHAR(32) NOT NULL,
+            discord_username VARCHAR(255) NOT NULL,
+            discord_display_name VARCHAR(255) NOT NULL,
+            created_at DATETIME NOT NULL,
+            updated_at DATETIME NOT NULL,
+            UNIQUE KEY unique_user_id (user_id),
+            UNIQUE KEY unique_discord_user_id (discord_user_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+    );
+
+    $pdo->exec(
+        'ALTER TABLE user_discord_links
+         ADD COLUMN IF NOT EXISTS discord_display_name VARCHAR(255) NOT NULL DEFAULT "" AFTER discord_username'
+    );
+}
+
+function discordConfig(array $config): array
+{
+    return $config['discord'] ?? [];
+}
+
+function discordRedirectUri(array $config): string
+{
+    $discord = discordConfig($config);
+    $configured = trim((string)($discord['redirect_uri'] ?? ''));
+    if ($configured !== '') {
+        return $configured;
+    }
+
+    return buildAppUrl($config, '?page=discord-callback');
+}
+
+function discordAuthorizationUrl(array $config, string $state): string
+{
+    $discord = discordConfig($config);
+    $clientId = trim((string)($discord['client_id'] ?? ''));
+    if ($clientId === '') {
+        throw new RuntimeException('Discord OAuth is not configured. Add discord.client_id in config.php.');
+    }
+
+    return 'https://discord.com/oauth2/authorize?' . http_build_query([
+        'client_id' => $clientId,
+        'response_type' => 'code',
+        'redirect_uri' => discordRedirectUri($config),
+        'scope' => 'identify guilds.join',
+        'prompt' => 'consent',
+        'state' => $state,
+    ]);
+}
+
+function discordExchangeCodeForToken(array $config, string $code): array
+{
+    $discord = discordConfig($config);
+    $clientId = trim((string)($discord['client_id'] ?? ''));
+    $clientSecret = trim((string)($discord['client_secret'] ?? ''));
+
+    if ($clientId === '' || $clientSecret === '') {
+        throw new RuntimeException('Discord OAuth is not configured. Add discord.client_id and discord.client_secret in config.php.');
+    }
+
+    $payload = http_build_query([
+        'client_id' => $clientId,
+        'client_secret' => $clientSecret,
+        'grant_type' => 'authorization_code',
+        'code' => $code,
+        'redirect_uri' => discordRedirectUri($config),
+    ]);
+
+    $ch = curl_init('https://discord.com/api/v10/oauth2/token');
+    if ($ch === false) {
+        throw new RuntimeException('Failed to initialize Discord token request.');
+    }
+
+    curl_setopt_array($ch, [
+        CURLOPT_POST => true,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => ['Content-Type: application/x-www-form-urlencoded'],
+        CURLOPT_POSTFIELDS => $payload,
+        CURLOPT_TIMEOUT => 15,
+    ]);
+
+    $response = curl_exec($ch);
+    $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    $error = curl_error($ch);
+    curl_close($ch);
+
+    if ($response === false) {
+        throw new RuntimeException('Discord token request failed: ' . $error);
+    }
+
+    if ($status < 200 || $status >= 300) {
+        throw new RuntimeException('Discord token API returned HTTP ' . $status . ': ' . $response);
+    }
+
+    $decoded = json_decode($response, true);
+    if (!is_array($decoded)) {
+        throw new RuntimeException('Discord token API returned invalid JSON.');
+    }
+
+    return $decoded;
+}
+
+function discordFetchCurrentUser(string $accessToken): array
+{
+    $ch = curl_init('https://discord.com/api/v10/users/@me');
+    if ($ch === false) {
+        throw new RuntimeException('Failed to initialize Discord user request.');
+    }
+
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => ['Authorization: Bearer ' . $accessToken],
+        CURLOPT_TIMEOUT => 15,
+    ]);
+
+    $response = curl_exec($ch);
+    $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    $error = curl_error($ch);
+    curl_close($ch);
+
+    if ($response === false) {
+        throw new RuntimeException('Discord user request failed: ' . $error);
+    }
+
+    if ($status < 200 || $status >= 300) {
+        throw new RuntimeException('Discord user API returned HTTP ' . $status . ': ' . $response);
+    }
+
+    $decoded = json_decode($response, true);
+    if (!is_array($decoded)) {
+        throw new RuntimeException('Discord user API returned invalid JSON.');
+    }
+
+    return $decoded;
+}
+
 function banExpiredPendingAccounts(PDO $pdo): void
 {
     $banExpired = $pdo->prepare(
@@ -233,10 +377,12 @@ $javaDownloadUrl = $configMissing ? 'https://www.java.com/download/' : trim((str
 $discordUrl = $configMissing ? 'https://discord.gg/' : trim((string)($config['app']['discord_url'] ?? 'https://discord.gg/'));
 
 $page = isset($_GET['page']) && is_string($_GET['page']) ? strtolower(trim($_GET['page'])) : '';
-$allowedPages = ['login', 'register', 'forgot-password', 'download', 'reset-password', 'change-password', 'activate'];
+$allowedPages = ['login', 'register', 'forgot-password', 'download', 'reset-password', 'change-password', 'activate', 'discord-link', 'discord-callback'];
 if (!in_array($page, $allowedPages, true)) {
     $page = isset($_SESSION['user_id']) ? 'download' : 'login';
 }
+
+$discordLink = null;
 
 if ($page === 'activate' && isset($_GET['token']) && is_string($_GET['token']) && $_GET['token'] !== '') {
     $token = trim($_GET['token']);
@@ -286,6 +432,92 @@ if ($page === 'activate' && isset($_GET['token']) && is_string($_GET['token']) &
             $errors[] = 'Could not activate account right now. Please try again later.';
             error_log('Activation error: ' . $e->getMessage());
             $page = 'login';
+        }
+    }
+}
+
+
+if ($page === 'discord-link') {
+    if (!isset($_SESSION['user_id'])) {
+        $infoMessage = 'Please sign in first.';
+        $page = 'login';
+    } elseif (requireConfiguredOrFail($configMissing, $errors)) {
+        try {
+            $state = bin2hex(random_bytes(16));
+            $_SESSION['discord_oauth_state'] = $state;
+            redirectTo(discordAuthorizationUrl($config, $state));
+        } catch (Throwable $e) {
+            $errors[] = 'Could not start Discord linking right now. Please try again later.';
+            error_log('Discord oauth start error: ' . $e->getMessage());
+            $page = 'download';
+        }
+    }
+}
+
+if ($page === 'discord-callback') {
+    if (!isset($_SESSION['user_id'])) {
+        $infoMessage = 'Please sign in first.';
+        $page = 'login';
+    } else {
+        $stateFromQuery = isset($_GET['state']) && is_string($_GET['state']) ? trim($_GET['state']) : '';
+        $code = isset($_GET['code']) && is_string($_GET['code']) ? trim($_GET['code']) : '';
+        $expectedState = isset($_SESSION['discord_oauth_state']) && is_string($_SESSION['discord_oauth_state']) ? $_SESSION['discord_oauth_state'] : '';
+        unset($_SESSION['discord_oauth_state']);
+
+        if ($code === '' || $stateFromQuery === '' || $expectedState === '' || !hash_equals($expectedState, $stateFromQuery)) {
+            $errors[] = 'Discord link request is invalid or expired. Please try again.';
+            $page = 'download';
+        } elseif (requireConfiguredOrFail($configMissing, $errors)) {
+            try {
+                $pdo = pdoFromConfig($config);
+                ensureDiscordLinksTable($pdo);
+
+                $tokenData = discordExchangeCodeForToken($config, $code);
+                $accessToken = (string)($tokenData['access_token'] ?? '');
+                if ($accessToken === '') {
+                    throw new RuntimeException('Discord token response did not include an access token.');
+                }
+
+                $discordUser = discordFetchCurrentUser($accessToken);
+                $discordUserId = trim((string)($discordUser['id'] ?? ''));
+                $discordUsername = trim((string)($discordUser['username'] ?? 'Discord user'));
+                $discordGlobalName = trim((string)($discordUser['global_name'] ?? ''));
+                $discordDisplayName = $discordGlobalName !== '' ? $discordGlobalName : $discordUsername;
+                if ($discordUserId === '') {
+                    throw new RuntimeException('Discord user response did not include an id.');
+                }
+
+                $discordConfig = discordConfig($config);
+                $roleManager = new DiscordRoleManager(
+                    trim((string)($discordConfig['bot_token'] ?? '')),
+                    trim((string)($discordConfig['guild_id'] ?? '')),
+                    trim((string)($discordConfig['verified_role_id'] ?? ''))
+                );
+                $roleManager->assignVerifiedRole($discordUserId, $accessToken);
+
+                $upsert = $pdo->prepare(
+                    'INSERT INTO user_discord_links (user_id, discord_user_id, discord_username, discord_display_name, created_at, updated_at)
+                     VALUES (:user_id, :discord_user_id, :discord_username, :discord_display_name, NOW(), NOW())
+                     ON DUPLICATE KEY UPDATE
+                        discord_user_id = VALUES(discord_user_id),
+                        discord_username = VALUES(discord_username),
+                        discord_display_name = VALUES(discord_display_name),
+                        updated_at = NOW()'
+                );
+                $upsert->execute([
+                    'user_id' => (int)$_SESSION['user_id'],
+                    'discord_user_id' => $discordUserId,
+                    'discord_username' => $discordUsername,
+                    'discord_display_name' => $discordDisplayName,
+                ]);
+
+                $successMessage = 'Discord account linked successfully. You now have access to the verified role flow.';
+                $page = 'download';
+            } catch (Throwable $e) {
+                $errors[] = 'Could not link Discord right now. Please try again later.';
+                error_log('Discord link callback error: ' . $e->getMessage());
+                $page = 'download';
+            }
         }
     }
 }
@@ -691,9 +923,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 }
 
-if (($page === 'download' || $page === 'change-password') && !isset($_SESSION['user_id'])) {
+if (($page === 'download' || $page === 'change-password' || $page === 'discord-link' || $page === 'discord-callback') && !isset($_SESSION['user_id'])) {
     $infoMessage = 'Please sign in first.';
     $page = 'login';
+}
+
+
+if ($page === 'download' && isset($_SESSION['user_id']) && requireConfiguredOrFail($configMissing, $errors)) {
+    try {
+        $pdo = pdoFromConfig($config);
+        ensureDiscordLinksTable($pdo);
+        $discordLookup = $pdo->prepare(
+            'SELECT discord_username, discord_display_name
+             FROM user_discord_links
+             WHERE user_id = :user_id
+             LIMIT 1'
+        );
+        $discordLookup->execute(['user_id' => (int)$_SESSION['user_id']]);
+        $discordLink = $discordLookup->fetch();
+    } catch (Throwable $e) {
+        error_log('Discord link lookup error: ' . $e->getMessage());
+    }
 }
 
 $resetTokenFromQuery = isset($_GET['token']) && is_string($_GET['token']) ? trim($_GET['token']) : '';
@@ -911,6 +1161,10 @@ $resetTokenFromQuery = isset($_GET['token']) && is_string($_GET['token']) ? trim
             <a class="btn-link" href="<?= htmlspecialchars($clientJarUrl, ENT_QUOTES, 'UTF-8') ?>">Download game client</a>
             <a class="btn-link secondary" href="<?= htmlspecialchars($javaDownloadUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Download Java</a>
             <a class="btn-link discord" href="<?= htmlspecialchars($discordUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Join Discord</a>
+            <a class="btn-link" href="?page=discord-link">Koppel Discord account (Verified role)</a>
+            <?php if ($discordLink): ?>
+                <p class="meta">Discord gekoppeld als <strong><?= htmlspecialchars((string)$discordLink['discord_display_name'], ENT_QUOTES, 'UTF-8') ?></strong> (@<?= htmlspecialchars((string)$discordLink['discord_username'], ENT_QUOTES, 'UTF-8') ?>).</p>
+            <?php endif; ?>
             <a class="btn-link secondary" href="?page=change-password">Change password</a>
             <a class="btn-link secondary" href="?logout=1">Sign out</a>
         </div>

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -173,14 +173,19 @@ function discordAuthorizationUrl(array $config, string $state): string
         throw new RuntimeException('Discord OAuth is not configured. Add discord.client_id in config.php.');
     }
 
+    $scopes = trim((string)($discord['oauth_scopes'] ?? 'identify guilds.join'));
+    if ($scopes == '') {
+        $scopes = 'identify guilds.join';
+    }
+
     return 'https://discord.com/oauth2/authorize?' . http_build_query([
         'client_id' => $clientId,
         'response_type' => 'code',
         'redirect_uri' => discordRedirectUri($config),
-        'scope' => 'identify guilds.join',
+        'scope' => $scopes,
         'prompt' => 'consent',
         'state' => $state,
-    ]);
+    ], '', '&', PHP_QUERY_RFC3986);
 }
 
 function discordExchangeCodeForToken(array $config, string $code): array
@@ -514,7 +519,7 @@ if ($page === 'discord-callback') {
                 $successMessage = 'Discord account linked successfully. You now have access to the verified role flow.';
                 $page = 'download';
             } catch (Throwable $e) {
-                $errors[] = 'Could not link Discord right now. Please try again later.';
+                $errors[] = 'Could not link Discord right now. Please try again later. Check that discord.redirect_uri exactly matches the Redirect URL in your Discord application settings.';
                 error_log('Discord link callback error: ' . $e->getMessage());
                 $page = 'download';
             }


### PR DESCRIPTION
### Motivation
- Persist the Discord display name (the `global_name` shown in Discord) alongside the username when users link a Discord account so the site can show the friendly display name in the UI.
- Ensure existing installs upgrade gracefully by adding the new column without requiring a manual migration.
- Improve clarity in the downloads page by showing both the display name and the username handle for linked Discord accounts.

### Description
- Capture `global_name` from the Discord `/users/@me` response and store it as `discord_display_name` (fallback to `username`) during the OAuth callback in `web-registration-simple/index.php`.
- Extend `user_discord_links` table creation to include `discord_display_name` and run an `ALTER TABLE ... ADD COLUMN IF NOT EXISTS discord_display_name` to support upgrades without manual migration in `web-registration-simple/index.php`.
- Update the download page to show the linked account as the display name plus `@username` and update `web-registration-simple/README.md` to document that both username and display name are stored.

### Testing
- Ran `php -l web-registration-simple/index.php` and `php -l web-registration-simple/DiscordRoleManager.php` and `php -l web-registration-simple/config.example.php` with no syntax errors.
- Started the built-in PHP dev server (`php -S 0.0.0.0:8080 -t web-registration-simple`) and performed a visual check of the download page UI via a Playwright script that produced a screenshot confirming the display name is shown.
- Automated checks listed above all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e9283568832991a9120f5701f297)