### PR TITLE
Add web admin user management, role assignment and Discord role sync

### DIFF
--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -29,6 +29,12 @@ return [
         'guild_id' => '123456789012345678',
         'bot_token' => 'REPLACE_ME',
         'verified_role_id' => '123456789012345678',
+        'premium_role_id' => '123456789012345678',
+        'moderator_role_id' => '123456789012345678',
+        'trial_moderator_role_id' => '123456789012345678',
+        'administrator_role_id' => '123456789012345678',
+        'developer_role_id' => '123456789012345678',
+        'banned_role_id' => '123456789012345678',
     ],
     'turnstile' => [
         'site_key' => '0x4AAAAA-REPLACE_ME',

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -1505,11 +1505,27 @@ if (isset($_SESSION['user_id']) && requireConfiguredOrFail($configMissing, $erro
                 'role_key' => $resolvedRoleKey,
                 'role_label' => $resolvedRoleLabel,
                 'unbantime' => (int)$roleRow['unbantime'],
+                'source' => 'database',
             ];
         }
     } catch (Throwable $e) {
         error_log('Current role debug lookup error: ' . $e->getMessage());
     }
+}
+
+if ($currentUserRoleDebug === null && isset($_SESSION['usergroupid'])) {
+    $fallbackGroupId = (int)$_SESSION['usergroupid'];
+    $fallbackRoleKey = findRoleKeyByUserGroupId($fallbackGroupId) ?? 'unknown';
+    $supportedRoles = getSupportedWebRoles();
+    $fallbackRoleLabel = isset($supportedRoles[$fallbackRoleKey]) ? (string)$supportedRoles[$fallbackRoleKey]['label'] : ucfirst(str_replace('_', ' ', $fallbackRoleKey));
+
+    $currentUserRoleDebug = [
+        'usergroupid' => $fallbackGroupId,
+        'role_key' => $fallbackRoleKey,
+        'role_label' => $fallbackRoleLabel,
+        'unbantime' => 0,
+        'source' => 'session',
+    ];
 }
 
 $adminManageableUsers = [];
@@ -1775,7 +1791,7 @@ if ($page === 'admin-users' && $hasAdminPanelAccess && requireConfiguredOrFail($
     <?php if ($page === 'download'): ?>
         <p class="meta">Welcome, <?= htmlspecialchars((string)($_SESSION['username'] ?? 'Player'), ENT_QUOTES, 'UTF-8') ?>. You are signed in.</p>
         <?php if (is_array($currentUserRoleDebug)): ?>
-            <p class="meta">Current role: <?= htmlspecialchars((string)$currentUserRoleDebug['role_label'], ENT_QUOTES, 'UTF-8') ?> (key: <?= htmlspecialchars((string)$currentUserRoleDebug['role_key'], ENT_QUOTES, 'UTF-8') ?>, usergroup: <?= (int)$currentUserRoleDebug['usergroupid'] ?>)</p>
+            <p class="meta">Current role: <?= htmlspecialchars((string)$currentUserRoleDebug['role_label'], ENT_QUOTES, 'UTF-8') ?> (key: <?= htmlspecialchars((string)$currentUserRoleDebug['role_key'], ENT_QUOTES, 'UTF-8') ?>, usergroup: <?= (int)$currentUserRoleDebug['usergroupid'] ?>, source: <?= htmlspecialchars((string)$currentUserRoleDebug['source'], ENT_QUOTES, 'UTF-8') ?>)</p>
         <?php endif; ?>
         <div class="downloads">
             <a class="btn-link" href="<?= htmlspecialchars($clientJarUrl, ENT_QUOTES, 'UTF-8') ?>">Download game client</a>

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -1599,6 +1599,9 @@ if ($page === 'admin-users' && $hasAdminPanelAccess && requireConfiguredOrFail($
             padding: 24px;
             box-shadow: 0 10px 30px rgba(0,0,0,.35);
         }
+        .card.admin-wide {
+            max-width: 980px;
+        }
         h1 { margin-top: 0; font-size: 1.4rem; }
         p.meta { color: #94a3b8; font-size: 0.95rem; }
         label { display: block; margin: 14px 0 6px; font-weight: 600; }
@@ -1672,19 +1675,46 @@ if ($page === 'admin-users' && $hasAdminPanelAccess && requireConfiguredOrFail($
             margin-top: 14px;
             display: grid;
             gap: 10px;
-            max-height: 360px;
+            max-height: 560px;
             overflow-y: auto;
+            padding-right: 4px;
         }
         .admin-user-card {
             border: 1px solid #334155;
-            border-radius: 8px;
-            padding: 10px;
+            border-radius: 10px;
+            padding: 14px;
             background: #0b1220;
+            display: grid;
+            grid-template-columns: minmax(220px, 1fr) minmax(240px, 1fr) 160px;
+            gap: 10px;
+            align-items: end;
         }
         .admin-user-row {
-            font-size: 0.9rem;
-            margin-bottom: 8px;
+            font-size: 0.95rem;
+            margin-bottom: 6px;
             color: #cbd5e1;
+            font-weight: 600;
+        }
+        .admin-role-label {
+            font-size: 0.8rem;
+            color: #94a3b8;
+            margin-bottom: 6px;
+            display: block;
+        }
+        .admin-actions {
+            display: flex;
+            align-items: end;
+        }
+        .admin-actions button {
+            margin-top: 0;
+        }
+        @media (max-width: 860px) {
+            .card.admin-wide {
+                max-width: 100%;
+            }
+            .admin-user-card {
+                grid-template-columns: 1fr;
+            }
         }
         select {
             width: 100%;
@@ -1698,7 +1728,7 @@ if ($page === 'admin-users' && $hasAdminPanelAccess && requireConfiguredOrFail($
     </style>
 </head>
 <body>
-<div class="card">
+<div class="card<?= $page === 'admin-users' ? ' admin-wide' : '' ?>">
     <h1>Dodian account portal</h1>
 
     <?php if ($configMissing): ?>
@@ -1850,24 +1880,35 @@ if ($page === 'admin-users' && $hasAdminPanelAccess && requireConfiguredOrFail($
 
     <?php if ($page === 'admin-users'): ?>
         <p class="meta">User management: only visible for usergroups 6, 10, and 18.</p>
+        <?php if (empty($adminManageableUsers)): ?>
+            <p class="meta">No users found.</p>
+        <?php endif; ?>
         <div class="admin-list">
             <?php foreach ($adminManageableUsers as $userRow): ?>
-                <div class="admin-user-card">
-                    <div class="admin-user-row">#<?= (int)$userRow['userid'] ?> - <?= htmlspecialchars((string)$userRow['username'], ENT_QUOTES, 'UTF-8') ?></div>
-                    <form method="post" action="">
-                        <input type="hidden" name="action" value="admin-update-role">
-                        <input type="hidden" name="user_id" value="<?= (int)$userRow['userid'] ?>">
-                        <label>Role</label>
-                        <select name="role_key" required>
+                <form method="post" action="" class="admin-user-card">
+                    <input type="hidden" name="action" value="admin-update-role">
+                    <input type="hidden" name="user_id" value="<?= (int)$userRow['userid'] ?>">
+
+                    <div>
+                        <div class="admin-user-row">#<?= (int)$userRow['userid'] ?> - <?= htmlspecialchars((string)$userRow['username'], ENT_QUOTES, 'UTF-8') ?></div>
+                        <span class="admin-role-label">Current role: <?= htmlspecialchars((string)(getSupportedWebRoles()[$userRow['role_key']]['label'] ?? ucfirst(str_replace('_', ' ', (string)$userRow['role_key']))), ENT_QUOTES, 'UTF-8') ?></span>
+                    </div>
+
+                    <div>
+                        <label class="admin-role-label" for="role_<?= (int)$userRow['userid'] ?>">Assign role</label>
+                        <select id="role_<?= (int)$userRow['userid'] ?>" name="role_key" required>
                             <?php foreach (getSupportedWebRoles() as $roleKey => $roleDefinition): ?>
                                 <option value="<?= htmlspecialchars((string)$roleKey, ENT_QUOTES, 'UTF-8') ?>" <?= $userRow['role_key'] === $roleKey ? 'selected' : '' ?>>
                                     <?= htmlspecialchars((string)$roleDefinition['label'], ENT_QUOTES, 'UTF-8') ?>
                                 </option>
                             <?php endforeach; ?>
                         </select>
-                        <button type="submit">Save</button>
-                    </form>
-                </div>
+                    </div>
+
+                    <div class="admin-actions">
+                        <button type="submit">Update role</button>
+                    </div>
+                </form>
             <?php endforeach; ?>
         </div>
         <div class="links">

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -1366,7 +1366,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if (empty($errors)) {
                     applyWebRoleToAccount($pdo, $userId, $roleKey);
 
-                    $targetLookup = $pdo->prepare('SELECT u.usergroupid, c.unbantime FROM user u INNER JOIN game_characters c ON c.id = u.userid WHERE u.userid = :userid LIMIT 1');
+                    $targetLookup = $pdo->prepare('SELECT u.usergroupid, COALESCE(c.unbantime, 0) AS unbantime FROM user u LEFT JOIN game_characters c ON c.id = u.userid WHERE u.userid = :userid LIMIT 1');
                     $targetLookup->execute(['userid' => $userId]);
                     $targetRow = $targetLookup->fetch();
                     if ($targetRow) {
@@ -1438,9 +1438,9 @@ if ($page === 'admin-users' && canAccessAdminPanel($currentSessionUserGroupId) &
     try {
         $pdo = pdoFromConfig($config);
         $listUsers = $pdo->query(
-            'SELECT u.userid, u.username, u.usergroupid, c.unbantime
+            'SELECT u.userid, u.username, u.usergroupid, COALESCE(c.unbantime, 0) AS unbantime
              FROM user u
-             INNER JOIN game_characters c ON c.id = u.userid
+             LEFT JOIN game_characters c ON c.id = u.userid
              ORDER BY u.userid DESC
              LIMIT 200'
         );


### PR DESCRIPTION
### Motivation
- Provide a web-based user management panel that allows administrators to change roles (including banning) and have those changes enforceable by the game server login checks.
- Map existing forum/usergroup semantics to web roles used by staff and to Discord roles so staff roles stay aligned across systems.
- Make Discord role assignment resilient and repeatable by persisting links and performing periodic re-syncs.

### Description
- Added new admin-only user management UI at `?page=admin-users` visible only to usergroups 6, 10 and 18 and a management button shown conditionally in the downloads UI (`web-registration-simple/index.php`).
- Implemented role definitions and role->usergroup mappings (verified, premium (11), moderator (5), trial moderator (9), administrator (6), developer (10), banned) and a function `applyWebRoleToAccount` that updates `user.usergroupid` and `game_characters` ban fields (`banned`, `ban_level`, `ban_reason`, `unbantime`) so the server-side `unbantime` login block works.
- Added Discord integration improvements: persistent `user_discord_links` table (auto-created via `ensureDiscordRoleSyncTable`), an upsert helper `upsertDiscordLink`, a role map from config and `syncDiscordRolesForLinkedUser` for assigning/removing role IDs, and `syncPendingDiscordRoles` which periodically syncs linked accounts (interval configurable as `DISCORD_ROLE_SYNC_INTERVAL_SECONDS`, default 1800s).
- Persisted OAuth tokens returned on link and perform immediate Discord role sync on account (re)link; added config fields for each managed Discord role in `web-registration-simple/config.example.php`.
- Kept existing nickname sync behavior and extended error messages for general Discord role-sync failures.

### Testing
- Ran PHP syntax check with `php -l web-registration-simple/index.php` which returned no syntax errors.
- Started the PHP built-in server with `php -S 0.0.0.0:8080 -t web-registration-simple` and captured a full-page screenshot with Playwright to validate the new admin UI (artifact: `artifacts/webpanel-userbeheer.png`).
- Exercised the Discord link flow changes via the local server run to confirm the new DB upsert path and immediate role sync code paths (no runtime PHP errors observed during the manual smoke run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69971836a5d483298c5207c30282cc17)