### PR TITLE
Refocus Discord role sync to users-only data model

### DIFF
--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -43,7 +43,8 @@ This demo uses the same flow as the game server:
 - Brevo sends an activation email with a link (`/?page=activate&token=...`) that is valid for 2 hours.
 - Clicking the link changes the account to `usergroupid = 40` (active), which is required for login.
 - Expired activation links auto-ban the account (`usergroupid = 8`).
-- Registration blocks duplicate usernames and duplicate email addresses.
+- Registration blocks duplicate usernames and duplicate email addresses (case-insensitive).
+- Disposable email domains are blocked by default; extend or override via `app.blocked_email_domains` in `config.php`.
 - Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and Discord actions (join + link).
 - Discord linking starts from the signed-in website only (`?page=discord-link`) and uses OAuth `identify` scope to connect a Discord account.
 - After linking, the configured bot updates the member nickname in the configured guild to the website/game username and assigns the configured Verified role during the linking flow.

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -16,6 +16,10 @@ return [
         'client_jar_url' => 'https://example.com/downloads/dodian-client.jar',
         'java_download_url' => 'https://www.java.com/download/',
         'discord_url' => 'https://discord.gg/your-server',
+        'blocked_email_domains' => [
+            'mailinator.com',
+            '10minutemail.com',
+        ],
     ],
     'brevo' => [
         'api_key' => 'xkeysib-REPLACE_ME',


### PR DESCRIPTION
### Motivation

- Remove dependence on character tables for role and ban state so role mapping is driven solely from the `user` table.
- Simplify Discord role sync and admin flows to avoid runtime failures when `game_characters`/`characters` rows or schemas are absent.

### Description

- Updated role resolution and context lookup so `resolveRoleByUserData`, `resolveUserRoleContext`, and related lookups use only `user.usergroupid` and a fixed `unbantime = 0` (see `web-registration-simple/index.php`).
- Replaced the old ban-check to use `isAccountCurrentlyBanned` querying `user.usergroupid === BANNED_USERGROUP_ID` instead of reading `unbantime` from character tables.
- Removed `setCharacterBanState` and all writes/updates to `game_characters`/`characters`, and removed its invocation from `applyWebRoleToAccount` so role changes only update `user.usergroupid`.
- Simplified periodic sync and admin listing queries in `syncPendingDiscordRoles` and admin pages to select from `user_discord_links` + `user` only (using `0 AS unbantime`) and added clearer error propagation on query failures.

### Testing

- Ran PHP syntax check with `php -l web-registration-simple/index.php`, which returned "No syntax errors detected" (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997368d1d3c8329b6333cb2f452460a)