### PR TITLE
Fix mystic client cache unzip flow to stop repeated downloads

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -13,6 +13,7 @@ This is the category in which you'll find documentation on how to set things up,
             <li><a href="/docs/guides/getting_started.md">Getting Started</a></li>
             <li><a href="/docs/guides/installing_mysql.md">Installing MySQL Database</a></li>
             <li style="margin-top: 5px"><a href="/docs/guides/glossary.md">Glossary</a></li>
+            <li><a href="/docs/guides/account_registration_website.md">Account Registration Website Guide</a></li>
         </ul>
     </li>
     <li><a href="/docs/contribution">Contribution</a>

--- a/docs/guides/account_registration_website.md
+++ b/docs/guides/account_registration_website.md
@@ -1,0 +1,102 @@
+# Account Registration Website Guide
+
+Deze gids beschrijft wat je nodig hebt om een simpele website te maken waarmee spelers accounts kunnen registreren voor deze Ub3r game-server.
+
+## Wat je al hebt in deze repo
+
+- De server gebruikt een MySQL-database.
+- Login valideert tegen de `user`-tabel.
+- De login-flow gebruikt een salted MD5-hash (`MD5(MD5(password) + salt)`).
+
+## Minimale eisen voor je registratie-website
+
+1. **Web-app runtime**
+   - Kies bijvoorbeeld Node.js (Express/Nest), PHP (Laravel), Python (Django/FastAPI) of Java (Spring Boot).
+
+2. **Database-connectie naar dezelfde MySQL**
+   - Verbind met dezelfde DB als de game-server (host, poort, naam, user, password).
+
+3. **Registratieformulier**
+   - Vereiste velden: username, email, password, password confirmation.
+   - Server-side validatie:
+     - username: 3-12 tekens, alleen letters/cijfers/underscore.
+     - email: geldig formaat.
+     - password: minimale lengte (bijv. 8+).
+
+4. **Password hashing compatibel met game-server**
+   - Genereer een random `salt` (30 chars, zoals DB-schema verwacht).
+   - Maak hash als:
+     - `passM = MD5(plainPassword)`
+     - `password = MD5(passM + salt)`
+   - Sla **beide** op: `password` en `salt`.
+
+5. **Database insert in `user`-tabel**
+   - Minimaal invullen:
+     - `username`
+     - `password`
+     - `salt`
+     - `email`
+     - `passworddate`
+     - `birthday_search`
+   - Laat waar mogelijk defaults van de tabel het werk doen.
+   - Gebruik altijd prepared statements (geen string-concatenatie).
+
+6. **Foutafhandeling en UX**
+   - Toon duidelijke errors bij:
+     - bestaande username
+     - zwak/ongeldig wachtwoord
+     - databasefout
+   - Succesmelding: account aangemaakt, je kunt nu inloggen in-game.
+
+7. **Security (belangrijk)**
+   - HTTPS verplicht.
+   - Rate limiting op registratie endpoint.
+   - CAPTCHA / bot bescherming.
+   - Input sanitization + prepared statements.
+   - Audit logging op registraties (ip, timestamp, username).
+
+## Let op over hashing
+
+Salted MD5 is verouderd voor moderne web-security. Voor compatibiliteit met deze server moet je dit voorlopig volgen. De beste lange-termijnstap is migreren naar een sterkere hash (bijv. Argon2id of bcrypt) in zowel game-server als webregistratie-flow.
+
+## Aanbevolen API-contract (voorbeeld)
+
+`POST /api/register`
+
+Request:
+
+```json
+{
+  "username": "Player123",
+  "email": "player@example.com",
+  "password": "SuperSecret123",
+  "confirmPassword": "SuperSecret123"
+}
+```
+
+Response success:
+
+```json
+{
+  "ok": true,
+  "message": "Account created"
+}
+```
+
+Response error:
+
+```json
+{
+  "ok": false,
+  "message": "Username already exists"
+}
+```
+
+## Checklist om live te gaan
+
+- [ ] DNS + domein
+- [ ] HTTPS-certificaat
+- [ ] Productie database credentials in secrets manager
+- [ ] Dagelijkse database backups
+- [ ] Monitoring + alerting op foutpercentages
+- [ ] Basis abuse protectie (rate-limit + captcha)

--- a/docs/guides/account_registration_website.md
+++ b/docs/guides/account_registration_website.md
@@ -38,7 +38,7 @@ This guide explains what you need to build a simple website that lets players re
      - `email`
      - `passworddate`
      - `birthday_search`
-   - Set `usergroupid` to `3` on insert (inactive/pending activation), then set to `40` after email activation.
+   - Set `usergroupid` to `3` on insert (inactive/pending activation), set to `40` after email activation, and set to ban group `8` when activation expires.
    - Let table defaults handle the rest when possible.
    - Always use prepared statements (no SQL string concatenation).
 
@@ -47,7 +47,7 @@ This guide explains what you need to build a simple website that lets players re
      - existing username
      - weak/invalid password
      - database error
-   - Success message example: account created, check your email to activate.
+   - Success message example: account created, check your email to activate (within 2 hours).
 
 7. **Security (important)**
    - HTTPS required.
@@ -56,6 +56,8 @@ This guide explains what you need to build a simple website that lets players re
    - Input sanitization + prepared statements.
    - Enforce unique e-mail usage (one account per e-mail).
    - Send activation mails through Brevo transactional API.
+   - Activation link lifetime: 2 hours.
+   - If not activated in time, move account to banned usergroup (`usergroupid = 8`).
    - Audit logging for registrations (IP, timestamp, username).
 
 ## Important note on hashing

--- a/docs/guides/account_registration_website.md
+++ b/docs/guides/account_registration_website.md
@@ -38,6 +38,7 @@ This guide explains what you need to build a simple website that lets players re
      - `email`
      - `passworddate`
      - `birthday_search`
+   - Set `usergroupid` to `3` on insert (inactive/pending activation), then set to `40` after email activation.
    - Let table defaults handle the rest when possible.
    - Always use prepared statements (no SQL string concatenation).
 
@@ -46,13 +47,15 @@ This guide explains what you need to build a simple website that lets players re
      - existing username
      - weak/invalid password
      - database error
-   - Success message example: account created, you can now log in in-game.
+   - Success message example: account created, check your email to activate.
 
 7. **Security (important)**
    - HTTPS required.
    - Rate limiting on registration endpoint.
    - CAPTCHA / bot protection.
    - Input sanitization + prepared statements.
+   - Enforce unique e-mail usage (one account per e-mail).
+   - Send activation mails through Brevo transactional API.
    - Audit logging for registrations (IP, timestamp, username).
 
 ## Important note on hashing
@@ -79,7 +82,8 @@ Success response:
 ```json
 {
   "ok": true,
-  "message": "Account created"
+  "message": "Account created, check your email to activate",
+  "activated": false
 }
 ```
 

--- a/docs/guides/account_registration_website.md
+++ b/docs/guides/account_registration_website.md
@@ -1,65 +1,65 @@
 # Account Registration Website Guide
 
-Deze gids beschrijft wat je nodig hebt om een simpele website te maken waarmee spelers accounts kunnen registreren voor deze Ub3r game-server.
+This guide explains what you need to build a simple website that lets players register accounts for this Ub3r game server.
 
-## Wat je al hebt in deze repo
+## What you already have in this repository
 
-- De server gebruikt een MySQL-database.
-- Login valideert tegen de `user`-tabel.
-- De login-flow gebruikt een salted MD5-hash (`MD5(MD5(password) + salt)`).
+- The server uses a MySQL database.
+- Login validation checks the `user` table.
+- The login flow uses a salted MD5 hash (`MD5(MD5(password) + salt)`).
 
-## Minimale eisen voor je registratie-website
+## Minimum requirements for your registration website
 
-1. **Web-app runtime**
-   - Kies bijvoorbeeld Node.js (Express/Nest), PHP (Laravel), Python (Django/FastAPI) of Java (Spring Boot).
+1. **Web app runtime**
+   - Use something like Node.js (Express/Nest), PHP (Laravel/plain PHP), Python (Django/FastAPI), or Java (Spring Boot).
 
-2. **Database-connectie naar dezelfde MySQL**
-   - Verbind met dezelfde DB als de game-server (host, poort, naam, user, password).
+2. **Database connection to the same MySQL instance**
+   - Connect to the same DB as the game server (host, port, name, user, password).
 
-3. **Registratieformulier**
-   - Vereiste velden: username, email, password, password confirmation.
-   - Server-side validatie:
-     - username: 3-12 tekens, alleen letters/cijfers/underscore.
-     - email: geldig formaat.
-     - password: minimale lengte (bijv. 8+).
+3. **Registration form**
+   - Required fields: username, email, password, password confirmation.
+   - Server-side validation:
+     - username: 3-12 chars, letters/numbers/underscore only.
+     - email: valid email format.
+     - password: minimum length (for example 8+).
 
-4. **Password hashing compatibel met game-server**
-   - Genereer een random `salt` (30 chars, zoals DB-schema verwacht).
-   - Maak hash als:
+4. **Password hashing compatible with the game server**
+   - Generate a random `salt` (30 chars, matching the DB schema).
+   - Build hash as:
      - `passM = MD5(plainPassword)`
      - `password = MD5(passM + salt)`
-   - Sla **beide** op: `password` en `salt`.
+   - Store **both** values: `password` and `salt`.
 
-5. **Database insert in `user`-tabel**
-   - Minimaal invullen:
+5. **Database insert into `user` table**
+   - Minimum fields to populate:
      - `username`
      - `password`
      - `salt`
      - `email`
      - `passworddate`
      - `birthday_search`
-   - Laat waar mogelijk defaults van de tabel het werk doen.
-   - Gebruik altijd prepared statements (geen string-concatenatie).
+   - Let table defaults handle the rest when possible.
+   - Always use prepared statements (no SQL string concatenation).
 
-6. **Foutafhandeling en UX**
-   - Toon duidelijke errors bij:
-     - bestaande username
-     - zwak/ongeldig wachtwoord
-     - databasefout
-   - Succesmelding: account aangemaakt, je kunt nu inloggen in-game.
+6. **Error handling and UX**
+   - Show clear errors for:
+     - existing username
+     - weak/invalid password
+     - database error
+   - Success message example: account created, you can now log in in-game.
 
-7. **Security (belangrijk)**
-   - HTTPS verplicht.
-   - Rate limiting op registratie endpoint.
-   - CAPTCHA / bot bescherming.
+7. **Security (important)**
+   - HTTPS required.
+   - Rate limiting on registration endpoint.
+   - CAPTCHA / bot protection.
    - Input sanitization + prepared statements.
-   - Audit logging op registraties (ip, timestamp, username).
+   - Audit logging for registrations (IP, timestamp, username).
 
-## Let op over hashing
+## Important note on hashing
 
-Salted MD5 is verouderd voor moderne web-security. Voor compatibiliteit met deze server moet je dit voorlopig volgen. De beste lange-termijnstap is migreren naar een sterkere hash (bijv. Argon2id of bcrypt) in zowel game-server als webregistratie-flow.
+Salted MD5 is outdated for modern web security. You need it for compatibility with this server today. The best long-term improvement is migrating to a stronger hash (for example Argon2id or bcrypt) in both the game server and registration flow.
 
-## Aanbevolen API-contract (voorbeeld)
+## Recommended API contract (example)
 
 `POST /api/register`
 
@@ -74,7 +74,7 @@ Request:
 }
 ```
 
-Response success:
+Success response:
 
 ```json
 {
@@ -83,7 +83,7 @@ Response success:
 }
 ```
 
-Response error:
+Error response:
 
 ```json
 {
@@ -92,11 +92,11 @@ Response error:
 }
 ```
 
-## Checklist om live te gaan
+## Go-live checklist
 
-- [ ] DNS + domein
-- [ ] HTTPS-certificaat
-- [ ] Productie database credentials in secrets manager
-- [ ] Dagelijkse database backups
-- [ ] Monitoring + alerting op foutpercentages
-- [ ] Basis abuse protectie (rate-limit + captcha)
+- [ ] DNS + domain
+- [ ] HTTPS certificate
+- [ ] Production DB credentials stored in a secrets manager
+- [ ] Daily database backups
+- [ ] Monitoring + alerting for error rates
+- [ ] Basic abuse protection (rate limit + CAPTCHA)

--- a/game-server/src/main/java/net/dodian/uber/game/model/entity/player/Player.java
+++ b/game-server/src/main/java/net/dodian/uber/game/model/entity/player/Player.java
@@ -321,8 +321,10 @@ public abstract class Player extends Entity {
     public void setTask(String input) {
         if (input.isEmpty())
             input = "-1,-1,0,0,0,0,-1";
+        slayerData.clear();
         String[] tasks = input.split(",");
         for (String task : tasks) slayerData.add(Integer.parseInt(task));
+        ensureSlayerDataSize();
     }
     public String saveTaskAsString() {
         StringBuilder tasks = new StringBuilder();
@@ -333,7 +335,15 @@ public abstract class Player extends Entity {
     }
     public ArrayList<Integer> getSlayerData() {
         //"-1,-1,0,0,0,0,-1" //master, taskid, total, currentAmount, streak, points, partner
+        ensureSlayerDataSize();
         return slayerData;
+    }
+
+    private void ensureSlayerDataSize() {
+        final int[] defaultSlayerData = {-1, -1, 0, 0, 0, 0, -1};
+        for (int i = slayerData.size(); i < defaultSlayerData.length; i++) {
+            slayerData.add(defaultSlayerData[i]);
+        }
     }
 
     public void setTravel(String input) {

--- a/game-server/src/main/kotlin/net/dodian/utilities/DotEnv.kt
+++ b/game-server/src/main/kotlin/net/dodian/utilities/DotEnv.kt
@@ -2,36 +2,49 @@ package net.dodian.utilities
 
 import io.github.cdimascio.dotenv.dotenv
 
-private val dotenv = dotenv()
+private val dotenv = dotenv {
+    ignoreIfMissing = true          // voorkomt crash als .env ontbreekt
+    ignoreIfMalformed = true        // optioneel, maar handig
+    systemProperties = true         // -DVAR=... (optioneel)
+    // systemEnv = true            // als jouw versie dit ondersteunt; zie noot hieronder
+}
+
+// helper: eerst OS env, dan .env, dan default
+private fun get(key: String): String? =
+    System.getenv(key) ?: dotenv[key]
+
+private fun getInt(key: String): Int? = get(key)?.toIntOrNull()
+private fun getLong(key: String): Long? = get(key)?.toLongOrNull()
+private fun getBool(key: String): Boolean? = get(key)?.lowercase()?.let { it == "true" || it == "1" || it == "yes" }
 
 // Server Settings
-val serverName = dotenv["SERVER_NAME"] ?: "Dodian"
-val serverPort = dotenv["SERVER_PORT"]?.toInt() ?: 43594
-val serverDebugMode = dotenv["SERVER_DEBUG_MODE"]?.toBoolean() ?: true
-val serverEnv = dotenv["SERVER_ENVIRONMENT"] ?: "prod"
+val serverName = get("SERVER_NAME") ?: "Dodian"
+val serverPort = getInt("SERVER_PORT") ?: 43894
+val serverDebugMode = getBool("SERVER_DEBUG_MODE") ?: true
+val serverEnv = get("SERVER_ENVIRONMENT") ?: "prod"
 
 // Database Settings
-val databaseHost = dotenv["DATABASE_HOST"] ?: "dodian.net"
-val databasePort = dotenv["DATABASE_PORT"]?.toInt() ?: 3306
-val databaseName = dotenv["DATABASE_NAME"] ?: "dodiannet"
-val databaseTablePrefix = dotenv["DATABASE_TABLE_PREFIX"] ?: ""
-val databaseUsername = dotenv["DATABASE_USERNAME"] ?: "moo"
-val databasePassword = dotenv["DATABASE_PASSWORD"] ?: "hehe"
-val databaseInitialize = dotenv["DATABASE_INITIALIZE"]?.toBoolean() ?: false
+val databaseHost = get("DATABASE_HOST") ?: "185.104.29.150"
+val databasePort = getInt("DATABASE_PORT") ?: 3306
+val databaseName = get("DATABASE_NAME") ?: "u43361p163932_dodian"
+val databaseTablePrefix = get("DATABASE_TABLE_PREFIX") ?: ""
+val databaseUsername = get("DATABASE_USERNAME") ?: "u43361p163932_dodian"
+val databasePassword = get("DATABASE_PASSWORD") ?: "MLJTX4CN4VtJGaKD5tcz"
+val databaseInitialize = getBool("DATABASE_INITIALIZE") ?: false
 
 // Game Settings - Various
-val gameWorldId = dotenv["GAME_WORLD_ID"]?.toInt() ?: 1
-val gameConnectionsPerIp = dotenv["GAME_CONNECTIONS_PER_IP"]?.toInt() ?: 2
+val gameWorldId = getInt("GAME_WORLD_ID") ?: 1
+val gameConnectionsPerIp = getInt("GAME_CONNECTIONS_PER_IP") ?: 2
 
 // Game Settings - Client
-val gameClientCustomVersion = dotenv["CLIENT_CUSTOM_VERSION"] ?: "dodian_client"
+val gameClientCustomVersion = get("CLIENT_CUSTOM_VERSION") ?: "dodian_client"
 
 // Database Pool Settings
-val databasePoolMinSize = dotenv["DATABASE_POOL_MIN_SIZE"]?.toInt() ?: 5
-val databasePoolMaxSize = dotenv["DATABASE_POOL_MAX_SIZE"]?.toInt() ?: 20
-val databasePoolConnectionTimeout = dotenv["DATABASE_POOL_CONNECTION_TIMEOUT"]?.toLong() ?: 30000L
-val databasePoolIdleTimeout = dotenv["DATABASE_POOL_IDLE_TIMEOUT"]?.toLong() ?: 600000L
-val databasePoolMaxLifetime = dotenv["DATABASE_POOL_MAX_LIFETIME"]?.toLong() ?: 1800000L
+val databasePoolMinSize = getInt("DATABASE_POOL_MIN_SIZE") ?: 5
+val databasePoolMaxSize = getInt("DATABASE_POOL_MAX_SIZE") ?: 20
+val databasePoolConnectionTimeout = getLong("DATABASE_POOL_CONNECTION_TIMEOUT") ?: 30000L
+val databasePoolIdleTimeout = getLong("DATABASE_POOL_IDLE_TIMEOUT") ?: 600000L
+val databasePoolMaxLifetime = getLong("DATABASE_POOL_MAX_LIFETIME") ?: 1800000L
 
 // Game Settings - Multipliers
-val gameMultiplierGlobalXp = dotenv["GAME_MULTIPLIER_GLOBAL_XP"]?.toInt() ?: 1
+val gameMultiplierGlobalXp = getInt("GAME_MULTIPLIER_GLOBAL_XP") ?: 1

--- a/mystic-updatedclient/src/com/runescape/CacheDownloader.java
+++ b/mystic-updatedclient/src/com/runescape/CacheDownloader.java
@@ -17,7 +17,7 @@ import com.runescape.util.Unzip;
 
 public class CacheDownloader {
 
-	private static final String CACHE_PATH = "http://www.Dodian.net/client/cache/";
+	private static final String CACHE_PATH = "http://www.exorth.net/dodian/";
 	private static final String CACHE_NAME = "cache.zip";
 
 	public static void init(boolean force) {

--- a/mystic-updatedclient/src/com/runescape/CacheDownloader.java
+++ b/mystic-updatedclient/src/com/runescape/CacheDownloader.java
@@ -35,7 +35,10 @@ public class CacheDownloader {
 				/**
 				 * Unzip the downloaded cache file
 				 */
-				Unzip.unZipIt(SignLink.findcachedir() + CACHE_NAME, SignLink.findcachedir(), true);
+				boolean unzipped = Unzip.unZipIt(SignLink.findcachedir() + CACHE_NAME, SignLink.findcachedir(), true);
+				if (!unzipped) {
+					throw new IllegalStateException("Could not unzip downloaded cache file.");
+				}
 
 				/**
 				 * Write new version

--- a/mystic-updatedclient/src/com/runescape/Client.java
+++ b/mystic-updatedclient/src/com/runescape/Client.java
@@ -13222,7 +13222,7 @@ public class Client extends GameApplet {
 			boldText.method382(0xffffff, 55, worldText, 78, true);
 			smallText.method382(0xffffff, 55, "Click to switch", 92, true);
 			Configuration.server_address = "localhost";
-			Configuration.server_port = 43594;
+			Configuration.server_port = 43894;
 		}
 
 		if (loginScreenState == 4) {

--- a/mystic-updatedclient/src/com/runescape/Configuration.java
+++ b/mystic-updatedclient/src/com/runescape/Configuration.java
@@ -1,5 +1,7 @@
 package com.runescape;
 
+import java.io.File;
+
 /**
  * The main configuration for the Client
  * 
@@ -27,8 +29,9 @@ public final class Configuration {
 	
 	public static final int CLIENT_VERSION = 317;
 
-	public static final String CACHE_DIRECTORY = "./Cache/";//System.getProperty("user.home") + File.separator + "OSRSPKV"+CLIENT_VERSION+"/";
-	
+	//public static final String CACHE_DIRECTORY = "./Cache/";//System.getProperty("user.home") + File.separator + "OSRSPKV"+CLIENT_VERSION+"/";
+    public static final String CACHE_DIRECTORY = System.getProperty("user.home") + File.separator + "Dodian-Exorth"+CLIENT_VERSION+"/";
+
 	public static boolean JAGCACHED_ENABLED = false;
 
 	/**

--- a/mystic-updatedclient/src/com/runescape/Configuration.java
+++ b/mystic-updatedclient/src/com/runescape/Configuration.java
@@ -23,7 +23,7 @@ public final class Configuration {
 	/**
 	 * The port of the server that the client will be connecting to
 	 */
-	public static int server_port = 43594;
+	public static int server_port = 43894;
 	
 	public static final int CLIENT_VERSION = 317;
 
@@ -157,7 +157,7 @@ public final class Configuration {
 	/**
 	 * Is the combat overlay box enabled?
 	 */
-	public static boolean combatOverlayBox = true;
+	public static boolean combatOverlayBox = false;
 	
 	/**
 	 * Enables bounty hunter interface

--- a/mystic-updatedclient/src/com/runescape/util/Unzip.java
+++ b/mystic-updatedclient/src/com/runescape/util/Unzip.java
@@ -3,6 +3,7 @@ package com.runescape.util;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -14,7 +15,7 @@ public class Unzip {
 	 * @param output zip file output folder
 	 * @param deleteAfter		Should the zip file be deleted afterwards?
 	 */
-	public static void unZipIt(String zipFile, String outputFolder, boolean deleteAfter) {
+	public static boolean unZipIt(String zipFile, String outputFolder, boolean deleteAfter) {
 
 		byte[] buffer = new byte[1024];
 
@@ -27,42 +28,54 @@ public class Unzip {
 			}
 
 			//get the zip file content
-			ZipInputStream zis =
-					new ZipInputStream(new FileInputStream(zipFile));
-			//get the zipped file list entry
-			ZipEntry ze = zis.getNextEntry();
+			try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile))) {
+				//get the zipped file list entry
+				ZipEntry ze = zis.getNextEntry();
+				while(ze!=null){
 
-			while(ze!=null){
+					String fileName = ze.getName();
+					File newFile = new File(outputFolder + File.separator + fileName);
+					String destinationPath = folder.getCanonicalPath() + File.separator;
+					String entryPath = newFile.getCanonicalPath();
 
-				String fileName = ze.getName();
-				File newFile = new File(outputFolder + File.separator + fileName);
+					if (!entryPath.startsWith(destinationPath)) {
+						throw new IOException("Blocked zip entry outside destination: " + fileName);
+					}
 
-				System.out.println("file unzip : "+ newFile.getAbsoluteFile());
+					System.out.println("file unzip : "+ newFile.getAbsoluteFile());
 
-				//create all non exists folders
-				//else you will hit FileNotFoundException for compressed folder
-				new File(newFile.getParent()).mkdirs();
+					if (ze.isDirectory()) {
+						newFile.mkdirs();
+						ze = zis.getNextEntry();
+						continue;
+					}
 
-				FileOutputStream fos = new FileOutputStream(newFile);
+					//create all non exists folders
+					//else you will hit FileNotFoundException for compressed folder
+					new File(newFile.getParent()).mkdirs();
 
-				int len;
-				while ((len = zis.read(buffer)) > 0) {
-					fos.write(buffer, 0, len);
+					try (FileOutputStream fos = new FileOutputStream(newFile)) {
+						int len;
+						while ((len = zis.read(buffer)) > 0) {
+							fos.write(buffer, 0, len);
+						}
+					}
+
+					ze = zis.getNextEntry();
 				}
 
-				fos.close();
-				ze = zis.getNextEntry();
+				zis.closeEntry();
 			}
-
-			zis.closeEntry();
-			zis.close();
 			
 			if(deleteAfter) {
 				new File(zipFile).delete();
 			}
 
+			return true;
+
 		}catch(Exception ex){
 			ex.printStackTrace();
+			return false;
 		}
 	}
 

--- a/web-registration-simple/.gitignore
+++ b/web-registration-simple/.gitignore
@@ -1,0 +1,1 @@
+config.php

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -20,6 +20,7 @@ A minimal PHP + HTML account portal with registration, login, downloads, activat
    - `discord.redirect_uri` (set this to `.../?page=discord-link`)
    - `discord.guild_id`
    - `discord.bot_token`
+   - `discord.verified_role_id` (role ID for the Verified role)
 4. Start locally:
 
 ```bash
@@ -45,8 +46,8 @@ This demo uses the same flow as the game server:
 - Registration blocks duplicate usernames and duplicate email addresses.
 - Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and Discord actions (join + link).
 - Discord linking starts from the signed-in website only (`?page=discord-link`) and uses OAuth `identify` scope to connect a Discord account.
-- After linking, the configured bot updates the member nickname in the configured guild to the website/game username for that linked Discord account during the linking flow.
-- The Discord bot must have `Manage Nicknames`, and its highest role position must be strictly above the member's highest role (same permissions are not enough; hierarchy wins, and guild owners still cannot be renamed). If this is wrong, linking still succeeds for the current session but nickname sync will show a concrete hierarchy hint.
+- After linking, the configured bot updates the member nickname in the configured guild to the website/game username and assigns the configured Verified role during the linking flow.
+- The Discord bot must have `Manage Nicknames` and `Manage Roles`. Its highest role position must be strictly above the member's highest role and above the Verified role (same permissions are not enough; hierarchy wins, and guild owners still cannot be renamed). If this is wrong, linking still succeeds for the current session but sync warnings will explain what failed.
 - If nickname sync returns Discord 404, verify `discord.guild_id` first (wrong guild or bot not in that guild can also cause 404), then verify the linked Discord account is a member of that guild.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 - Signed-in users can change their password from `?page=change-password` by confirming their current password.

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -8,6 +8,8 @@ A minimal PHP + HTML account portal with registration, login, downloads, activat
 2. Fill in your database credentials.
 3. Configure these required activation settings in `config.php`:
    - `app.base_url` (public URL of the registration page)
+   - `app.client_jar_url` (direct link to your single game client `.jar`)
+   - `app.java_download_url` (Java download page, defaults to java.com)
    - `brevo.api_key`
    - `brevo.sender_email`
    - `turnstile.site_key`
@@ -35,7 +37,7 @@ This demo uses the same flow as the game server:
 - Clicking the link changes the account to `usergroupid = 40` (active), which is required for login.
 - Expired activation links auto-ban the account (`usergroupid = 8`).
 - Registration blocks duplicate usernames and duplicate email addresses.
-- Successful login redirects users to `?page=download`.
+- Successful login redirects users to `?page=download` with one game client `.jar` download button and one Java download button.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 
 ## Security notes

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -47,6 +47,7 @@ This demo uses the same flow as the game server:
 - Discord linking starts from the signed-in website only (`?page=discord-link`) and uses OAuth `identify` scope to connect a Discord account.
 - After linking, the configured bot updates the member nickname in the configured guild to the website/game username for that linked Discord account during the linking flow.
 - The Discord bot must have `Manage Nicknames`, and its highest role position must be strictly above the member's highest role (same permissions are not enough; hierarchy wins, and guild owners still cannot be renamed). If this is wrong, linking still succeeds for the current session but nickname sync will show a concrete hierarchy hint.
+- If nickname sync returns Discord 404, verify `discord.guild_id` first (wrong guild or bot not in that guild can also cause 404), then verify the linked Discord account is a member of that guild.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 - Signed-in users can change their password from `?page=change-password` by confirming their current password.
 

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -46,6 +46,7 @@ This demo uses the same flow as the game server:
 - Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and Discord actions (join + link).
 - Discord linking starts from the signed-in website only (`?page=discord-link`) and uses OAuth `identify` scope to connect a Discord account.
 - After linking, the configured bot updates the member nickname in the configured guild to the website/game username and stores link metadata in `user_discord_links`.
+- The Discord bot must have `Manage Nicknames`, and its role must be above target member roles; otherwise linking still succeeds but nickname sync will show an admin action message.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 - Signed-in users can change their password from `?page=change-password` by confirming their current password.
 

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -10,6 +10,7 @@ A minimal PHP + HTML account portal with registration, login, downloads, activat
    - `app.base_url` (public URL of the registration page)
    - `app.client_jar_url` (direct link to your single game client `.jar`)
    - `app.java_download_url` (Java download page, defaults to java.com)
+   - `app.discord_url` (invite link for your Discord community)
    - `brevo.api_key`
    - `brevo.sender_email`
    - `turnstile.site_key`
@@ -37,7 +38,7 @@ This demo uses the same flow as the game server:
 - Clicking the link changes the account to `usergroupid = 40` (active), which is required for login.
 - Expired activation links auto-ban the account (`usergroupid = 8`).
 - Registration blocks duplicate usernames and duplicate email addresses.
-- Successful login redirects users to `?page=download` with one game client `.jar` download button and one Java download button.
+- Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and one Discord button.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 
 ## Security notes

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -1,12 +1,12 @@
 # Simple PHP Registration Website
 
-Een minimale registratiepagina in PHP + HTML, compatibel met de huidige Ub3r password-hash flow.
+A minimal PHP + HTML registration page compatible with the current Ub3r password-hash flow.
 
-## Starten
+## Getting started
 
-1. Kopieer `config.example.php` naar `config.php`.
-2. Vul je databasegegevens in.
-3. Start lokaal:
+1. Copy `config.example.php` to `config.php`.
+2. Fill in your database credentials.
+3. Start locally:
 
 ```bash
 php -S 0.0.0.0:8080 -t web-registration-simple
@@ -14,15 +14,15 @@ php -S 0.0.0.0:8080 -t web-registration-simple
 
 4. Open `http://localhost:8080`.
 
-## Compatibele password hash
+## Compatible password hash
 
-Deze demo gebruikt dezelfde flow als de game-server:
+This demo uses the same flow as the game server:
 
 - `passM = md5(password)`
 - `stored = md5(passM + salt)`
 
-## Veiligheidsnotities
+## Security notes
 
-- Gebruik HTTPS in productie.
-- Voeg rate limiting en captcha toe.
-- Sla `config.php` nooit in git op.
+- Use HTTPS in production.
+- Add rate limiting and CAPTCHA.
+- Never commit `config.php` to git.

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -43,7 +43,8 @@ This demo uses the same flow as the game server:
 - Brevo sends an activation email with a link (`/?page=activate&token=...`) that is valid for 2 hours.
 - Clicking the link changes the account to `usergroupid = 40` (active), which is required for login.
 - Expired activation links auto-ban the account (`usergroupid = 8`).
-- Registration blocks duplicate usernames and duplicate email addresses.
+- Registration blocks duplicate usernames and duplicate email addresses (case-insensitive).
+- Disposable email domains are blocked by default; extend or override via `app.blocked_email_domains` in `config.php`.
 - Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and Discord actions (join + link).
 - Discord linking starts from the signed-in website only (`?page=discord-link`) and uses OAuth `identify` scope to connect a Discord account.
 - After linking, the configured bot updates the member nickname in the configured guild to the website/game username and assigns the configured Verified role during the linking flow.

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -46,7 +46,7 @@ This demo uses the same flow as the game server:
 - Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and Discord actions (join + link).
 - Discord linking starts from the signed-in website only (`?page=discord-link`) and uses OAuth `identify` scope to connect a Discord account.
 - After linking, the configured bot updates the member nickname in the configured guild to the website/game username for that linked Discord account during the linking flow.
-- The Discord bot must have `Manage Nicknames`, and its role must be above target member roles; otherwise linking still succeeds for the current session but nickname sync will show an admin action message.
+- The Discord bot must have `Manage Nicknames`, and its highest role must be above the member's highest role (and it still cannot rename guild owners). If this is wrong, linking still succeeds for the current session but nickname sync will show a concrete hierarchy hint.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 - Signed-in users can change their password from `?page=change-password` by confirming their current password.
 

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -1,6 +1,6 @@
-# Simple PHP Registration Website
+# Simple PHP Account Website
 
-A minimal PHP + HTML registration page compatible with the current Ub3r password-hash flow.
+A minimal PHP + HTML account portal with registration, login, downloads, activation, and forgot-password flows compatible with the current Ub3r password-hash flow.
 
 ## Getting started
 
@@ -27,14 +27,16 @@ This demo uses the same flow as the game server:
 - `passM = md5(password)`
 - `stored = md5(passM + salt)`
 
-## Account activation and email uniqueness
+## Account activation, login, and password recovery
 
 - Registrations start as `usergroupid = 3` (inactive).
 - An activation token is stored in `user_activation_tokens`.
-- Brevo sends an activation email with a link (`/?token=...`) that is valid for 2 hours.
-- Clicking the link changes the account to `usergroupid = 40` (active).
+- Brevo sends an activation email with a link (`/?page=activate&token=...`) that is valid for 2 hours.
+- Clicking the link changes the account to `usergroupid = 40` (active), which is required for login.
 - Expired activation links auto-ban the account (`usergroupid = 8`).
 - Registration blocks duplicate usernames and duplicate email addresses.
+- Successful login redirects users to `?page=download`.
+- Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 
 ## Security notes
 

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -45,8 +45,8 @@ This demo uses the same flow as the game server:
 - Registration blocks duplicate usernames and duplicate email addresses.
 - Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and Discord actions (join + link).
 - Discord linking starts from the signed-in website only (`?page=discord-link`) and uses OAuth `identify` scope to connect a Discord account.
-- After linking, the configured bot updates the member nickname in the configured guild to the website/game username and stores link metadata in `user_discord_links`.
-- The Discord bot must have `Manage Nicknames`, and its role must be above target member roles; otherwise linking still succeeds but nickname sync will show an admin action message.
+- After linking, the configured bot updates the member nickname in the configured guild to the website/game username for that linked Discord account during the linking flow.
+- The Discord bot must have `Manage Nicknames`, and its role must be above target member roles; otherwise linking still succeeds for the current session but nickname sync will show an admin action message.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 - Signed-in users can change their password from `?page=change-password` by confirming their current password.
 

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -1,0 +1,28 @@
+# Simple PHP Registration Website
+
+Een minimale registratiepagina in PHP + HTML, compatibel met de huidige Ub3r password-hash flow.
+
+## Starten
+
+1. Kopieer `config.example.php` naar `config.php`.
+2. Vul je databasegegevens in.
+3. Start lokaal:
+
+```bash
+php -S 0.0.0.0:8080 -t web-registration-simple
+```
+
+4. Open `http://localhost:8080`.
+
+## Compatibele password hash
+
+Deze demo gebruikt dezelfde flow als de game-server:
+
+- `passM = md5(password)`
+- `stored = md5(passM + salt)`
+
+## Veiligheidsnotities
+
+- Gebruik HTTPS in productie.
+- Voeg rate limiting en captcha toe.
+- Sla `config.php` nooit in git op.

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -15,6 +15,11 @@ A minimal PHP + HTML account portal with registration, login, downloads, activat
    - `brevo.sender_email`
    - `turnstile.site_key`
    - `turnstile.secret_key`
+   - `discord.client_id`
+   - `discord.client_secret`
+   - `discord.redirect_uri` (set this to `.../?page=discord-link`)
+   - `discord.guild_id`
+   - `discord.bot_token`
 4. Start locally:
 
 ```bash
@@ -38,7 +43,9 @@ This demo uses the same flow as the game server:
 - Clicking the link changes the account to `usergroupid = 40` (active), which is required for login.
 - Expired activation links auto-ban the account (`usergroupid = 8`).
 - Registration blocks duplicate usernames and duplicate email addresses.
-- Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and one Discord button.
+- Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and Discord actions (join + link).
+- Discord linking starts from the signed-in website only (`?page=discord-link`) and uses OAuth `identify` scope to connect a Discord account.
+- After linking, the configured bot updates the member nickname in the configured guild to the website/game username and stores link metadata in `user_discord_links`.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 - Signed-in users can change their password from `?page=change-password` by confirming their current password.
 

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -1,6 +1,6 @@
 # Simple PHP Account Website
 
-A minimal PHP + HTML account portal with registration, login, downloads, activation, and forgot-password flows compatible with the current Ub3r password-hash flow.
+A minimal PHP + HTML account portal with registration, login, downloads, activation, forgot-password, and in-session change-password flows compatible with the current Ub3r password-hash flow.
 
 ## Getting started
 
@@ -40,6 +40,7 @@ This demo uses the same flow as the game server:
 - Registration blocks duplicate usernames and duplicate email addresses.
 - Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and one Discord button.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
+- Signed-in users can change their password from `?page=change-password` by confirming their current password.
 
 ## Security notes
 

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -46,7 +46,7 @@ This demo uses the same flow as the game server:
 - Successful login redirects users to `?page=download` with one game client `.jar` download button, one Java download button, and Discord actions (join + link).
 - Discord linking starts from the signed-in website only (`?page=discord-link`) and uses OAuth `identify` scope to connect a Discord account.
 - After linking, the configured bot updates the member nickname in the configured guild to the website/game username for that linked Discord account during the linking flow.
-- The Discord bot must have `Manage Nicknames`, and its highest role must be above the member's highest role (and it still cannot rename guild owners). If this is wrong, linking still succeeds for the current session but nickname sync will show a concrete hierarchy hint.
+- The Discord bot must have `Manage Nicknames`, and its highest role position must be strictly above the member's highest role (same permissions are not enough; hierarchy wins, and guild owners still cannot be renamed). If this is wrong, linking still succeeds for the current session but nickname sync will show a concrete hierarchy hint.
 - Forgot password stores reset tokens in `user_password_reset_tokens` and emails `?page=reset-password&token=...` links for active accounts.
 - Signed-in users can change their password from `?page=change-password` by confirming their current password.
 

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -6,13 +6,17 @@ A minimal PHP + HTML registration page compatible with the current Ub3r password
 
 1. Copy `config.example.php` to `config.php`.
 2. Fill in your database credentials.
-3. Start locally:
+3. Configure these required activation settings in `config.php`:
+   - `app.base_url` (public URL of the registration page)
+   - `brevo.api_key`
+   - `brevo.sender_email`
+4. Start locally:
 
 ```bash
 php -S 0.0.0.0:8080 -t web-registration-simple
 ```
 
-4. Open `http://localhost:8080`.
+5. Open `http://localhost:8080`.
 
 ## Compatible password hash
 
@@ -20,6 +24,14 @@ This demo uses the same flow as the game server:
 
 - `passM = md5(password)`
 - `stored = md5(passM + salt)`
+
+## Account activation and email uniqueness
+
+- Registrations start as `usergroupid = 3` (inactive).
+- An activation token is stored in `user_activation_tokens`.
+- Brevo sends an activation email with a link (`/?token=...`).
+- Clicking the link changes the account to `usergroupid = 40` (active).
+- Registration blocks duplicate usernames and duplicate email addresses.
 
 ## Security notes
 

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -10,6 +10,8 @@ A minimal PHP + HTML registration page compatible with the current Ub3r password
    - `app.base_url` (public URL of the registration page)
    - `brevo.api_key`
    - `brevo.sender_email`
+   - `turnstile.site_key`
+   - `turnstile.secret_key`
 4. Start locally:
 
 ```bash
@@ -37,5 +39,6 @@ This demo uses the same flow as the game server:
 ## Security notes
 
 - Use HTTPS in production.
-- Add rate limiting and CAPTCHA.
+- Cloudflare Turnstile is integrated and validated server-side for each registration.
+- Add rate limiting as a second layer.
 - Never commit `config.php` to git.

--- a/web-registration-simple/README.md
+++ b/web-registration-simple/README.md
@@ -29,8 +29,9 @@ This demo uses the same flow as the game server:
 
 - Registrations start as `usergroupid = 3` (inactive).
 - An activation token is stored in `user_activation_tokens`.
-- Brevo sends an activation email with a link (`/?token=...`).
+- Brevo sends an activation email with a link (`/?token=...`) that is valid for 2 hours.
 - Clicking the link changes the account to `usergroupid = 40` (active).
+- Expired activation links auto-ban the account (`usergroupid = 8`).
 - Registration blocks duplicate usernames and duplicate email addresses.
 
 ## Security notes

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -15,6 +15,7 @@ return [
         'base_url' => 'http://localhost:8080',
         'client_jar_url' => 'https://example.com/downloads/dodian-client.jar',
         'java_download_url' => 'https://www.java.com/download/',
+        'discord_url' => 'https://discord.gg/your-server',
     ],
     'brevo' => [
         'api_key' => 'xkeysib-REPLACE_ME',

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -11,4 +11,12 @@ return [
         'password' => 'abcd1234',
         'charset' => 'utf8mb4',
     ],
+    'app' => [
+        'base_url' => 'http://localhost:8080',
+    ],
+    'brevo' => [
+        'api_key' => 'xkeysib-REPLACE_ME',
+        'sender_email' => 'noreply@example.com',
+        'sender_name' => 'Dodian',
+    ],
 ];

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -29,6 +29,12 @@ return [
         'guild_id' => '123456789012345678',
         'bot_token' => 'REPLACE_ME',
         'verified_role_id' => '123456789012345678',
+        'premium_role_id' => '123456789012345678',
+        'moderator_role_id' => '123456789012345678',
+        'trial_moderator_role_id' => '123456789012345678',
+        'administrator_role_id' => '123456789012345678',
+        'developer_role_id' => '123456789012345678',
+        'banned_role_id' => '123456789012345678',
     ],
     'turnstile' => [
         'site_key' => '0x4AAAAA-REPLACE_ME',

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'db' => [
+        'host' => '127.0.0.1',
+        'port' => 3306,
+        'name' => 'dodiannet',
+        'user' => 'dodian_game',
+        'password' => 'abcd1234',
+        'charset' => 'utf8mb4',
+    ],
+];

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -13,6 +13,8 @@ return [
     ],
     'app' => [
         'base_url' => 'http://localhost:8080',
+        'client_jar_url' => 'https://example.com/downloads/dodian-client.jar',
+        'java_download_url' => 'https://www.java.com/download/',
     ],
     'brevo' => [
         'api_key' => 'xkeysib-REPLACE_ME',

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -22,6 +22,13 @@ return [
         'sender_email' => 'noreply@example.com',
         'sender_name' => 'Dodian',
     ],
+    'discord' => [
+        'client_id' => '123456789012345678',
+        'client_secret' => 'REPLACE_ME',
+        'redirect_uri' => 'http://localhost:8080/?page=discord-link',
+        'guild_id' => '123456789012345678',
+        'bot_token' => 'REPLACE_ME',
+    ],
     'turnstile' => [
         'site_key' => '0x4AAAAA-REPLACE_ME',
         'secret_key' => '0x4AAAAA-REPLACE_ME',

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -19,4 +19,8 @@ return [
         'sender_email' => 'noreply@example.com',
         'sender_name' => 'Dodian',
     ],
+    'turnstile' => [
+        'site_key' => '0x4AAAAA-REPLACE_ME',
+        'secret_key' => '0x4AAAAA-REPLACE_ME',
+    ],
 ];

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -16,6 +16,10 @@ return [
         'client_jar_url' => 'https://example.com/downloads/dodian-client.jar',
         'java_download_url' => 'https://www.java.com/download/',
         'discord_url' => 'https://discord.gg/your-server',
+        'blocked_email_domains' => [
+            'mailinator.com',
+            '10minutemail.com',
+        ],
     ],
     'brevo' => [
         'api_key' => 'xkeysib-REPLACE_ME',

--- a/web-registration-simple/config.example.php
+++ b/web-registration-simple/config.example.php
@@ -28,6 +28,7 @@ return [
         'redirect_uri' => 'http://localhost:8080/?page=discord-link',
         'guild_id' => '123456789012345678',
         'bot_token' => 'REPLACE_ME',
+        'verified_role_id' => '123456789012345678',
     ],
     'turnstile' => [
         'site_key' => '0x4AAAAA-REPLACE_ME',

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -2036,7 +2036,7 @@ if ($page === 'admin-users' && $hasAdminPanelAccess && requireConfiguredOrFail($
     <?php if ($page === 'download'): ?>
         <p class="meta">Welcome, <?= htmlspecialchars((string)($_SESSION['username'] ?? 'Player'), ENT_QUOTES, 'UTF-8') ?>. You are signed in.</p>
         <?php if (is_array($currentUserRoleDebug)): ?>
-            <p class="meta">Current role: <?= htmlspecialchars((string)$currentUserRoleDebug['role_label'], ENT_QUOTES, 'UTF-8') ?> (key: <?= htmlspecialchars((string)$currentUserRoleDebug['role_key'], ENT_QUOTES, 'UTF-8') ?>, usergroup: <?= (int)$currentUserRoleDebug['usergroupid'] ?>, source: <?= htmlspecialchars((string)$currentUserRoleDebug['source'], ENT_QUOTES, 'UTF-8') ?>)</p>
+            <p class="meta">Current role: <?= htmlspecialchars((string)$currentUserRoleDebug['role_label'], ENT_QUOTES, 'UTF-8') ?> </p>
         <?php endif; ?>
         <div class="downloads">
             <a class="btn-link" href="<?= htmlspecialchars($clientJarUrl, ENT_QUOTES, 'UTF-8') ?>">Download game client</a>

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -1505,11 +1505,27 @@ if (isset($_SESSION['user_id']) && requireConfiguredOrFail($configMissing, $erro
                 'role_key' => $resolvedRoleKey,
                 'role_label' => $resolvedRoleLabel,
                 'unbantime' => (int)$roleRow['unbantime'],
+                'source' => 'database',
             ];
         }
     } catch (Throwable $e) {
         error_log('Current role debug lookup error: ' . $e->getMessage());
     }
+}
+
+if ($currentUserRoleDebug === null && isset($_SESSION['usergroupid'])) {
+    $fallbackGroupId = (int)$_SESSION['usergroupid'];
+    $fallbackRoleKey = findRoleKeyByUserGroupId($fallbackGroupId) ?? 'unknown';
+    $supportedRoles = getSupportedWebRoles();
+    $fallbackRoleLabel = isset($supportedRoles[$fallbackRoleKey]) ? (string)$supportedRoles[$fallbackRoleKey]['label'] : ucfirst(str_replace('_', ' ', $fallbackRoleKey));
+
+    $currentUserRoleDebug = [
+        'usergroupid' => $fallbackGroupId,
+        'role_key' => $fallbackRoleKey,
+        'role_label' => $fallbackRoleLabel,
+        'unbantime' => 0,
+        'source' => 'session',
+    ];
 }
 
 $adminManageableUsers = [];
@@ -1775,7 +1791,7 @@ if ($page === 'admin-users' && $hasAdminPanelAccess && requireConfiguredOrFail($
     <?php if ($page === 'download'): ?>
         <p class="meta">Welcome, <?= htmlspecialchars((string)($_SESSION['username'] ?? 'Player'), ENT_QUOTES, 'UTF-8') ?>. You are signed in.</p>
         <?php if (is_array($currentUserRoleDebug)): ?>
-            <p class="meta">Current role: <?= htmlspecialchars((string)$currentUserRoleDebug['role_label'], ENT_QUOTES, 'UTF-8') ?> (key: <?= htmlspecialchars((string)$currentUserRoleDebug['role_key'], ENT_QUOTES, 'UTF-8') ?>, usergroup: <?= (int)$currentUserRoleDebug['usergroupid'] ?>)</p>
+            <p class="meta">Current role: <?= htmlspecialchars((string)$currentUserRoleDebug['role_label'], ENT_QUOTES, 'UTF-8') ?> (key: <?= htmlspecialchars((string)$currentUserRoleDebug['role_key'], ENT_QUOTES, 'UTF-8') ?>, usergroup: <?= (int)$currentUserRoleDebug['usergroupid'] ?>, source: <?= htmlspecialchars((string)$currentUserRoleDebug['source'], ENT_QUOTES, 'UTF-8') ?>)</p>
         <?php endif; ?>
         <div class="downloads">
             <a class="btn-link" href="<?= htmlspecialchars($clientJarUrl, ENT_QUOTES, 'UTF-8') ?>">Download game client</a>

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+$configPath = __DIR__ . '/config.php';
+$configMissing = !file_exists($configPath);
+$config = $configMissing ? null : require $configPath;
+
+function randomSalt(int $length = 30): string
+{
+    $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    $alphabetLen = strlen($alphabet);
+    $salt = '';
+
+    for ($i = 0; $i < $length; $i++) {
+        $salt .= $alphabet[random_int(0, $alphabetLen - 1)];
+    }
+
+    return $salt;
+}
+
+function dodianPasswordHash(string $password, string $salt): string
+{
+    $passM = md5($password);
+    return md5($passM . $salt);
+}
+
+function pdoFromConfig(array $config): PDO
+{
+    $db = $config['db'];
+    $dsn = sprintf('mysql:host=%s;port=%d;dbname=%s;charset=%s', $db['host'], $db['port'], $db['name'], $db['charset']);
+
+    return new PDO($dsn, $db['user'], $db['password'], [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+}
+
+$errors = [];
+$successMessage = null;
+$username = '';
+$email = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if ($configMissing) {
+        $errors[] = 'Server is nog niet geconfigureerd. Kopieer config.example.php naar config.php en vul DB-gegevens in.';
+    }
+
+    $username = trim((string)($_POST['username'] ?? ''));
+    $email = trim((string)($_POST['email'] ?? ''));
+    $password = (string)($_POST['password'] ?? '');
+    $confirmPassword = (string)($_POST['confirm_password'] ?? '');
+
+    if (!preg_match('/^[A-Za-z0-9_]{3,12}$/', $username)) {
+        $errors[] = 'Username moet 3-12 tekens zijn en alleen letters, cijfers of underscore bevatten.';
+    }
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Voer een geldig e-mailadres in.';
+    }
+
+    if (strlen($password) < 8) {
+        $errors[] = 'Wachtwoord moet minimaal 8 tekens bevatten.';
+    }
+
+    if ($password !== $confirmPassword) {
+        $errors[] = 'Wachtwoorden komen niet overeen.';
+    }
+
+    if (!$configMissing && empty($errors)) {
+        try {
+            $pdo = pdoFromConfig($config);
+
+            $stmt = $pdo->prepare('SELECT 1 FROM user WHERE username = :username LIMIT 1');
+            $stmt->execute(['username' => $username]);
+            if ($stmt->fetch()) {
+                $errors[] = 'Deze username bestaat al.';
+            } else {
+                $salt = randomSalt(30);
+                $storedPassword = dodianPasswordHash($password, $salt);
+
+                $insert = $pdo->prepare(
+                    'INSERT INTO user (username, password, salt, email, passworddate, birthday_search, joindate)
+                     VALUES (:username, :password, :salt, :email, :passworddate, :birthday_search, :joindate)'
+                );
+
+                $insert->execute([
+                    'username' => $username,
+                    'password' => $storedPassword,
+                    'salt' => $salt,
+                    'email' => $email,
+                    'passworddate' => date('Y-m-d H:i:s'),
+                    'birthday_search' => '',
+                    'joindate' => time(),
+                ]);
+
+                $successMessage = 'Account aangemaakt! Je kunt nu inloggen in-game.';
+                $username = '';
+                $email = '';
+            }
+        } catch (Throwable $e) {
+            $errors[] = 'Registratie mislukt door een server/database fout.';
+            error_log('Registration error: ' . $e->getMessage());
+        }
+    }
+}
+?>
+<!doctype html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dodian Account Registratie</title>
+    <style>
+        :root { color-scheme: dark; }
+        body {
+            margin: 0;
+            font-family: Inter, system-ui, Arial, sans-serif;
+            background: #0f172a;
+            color: #e2e8f0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            padding: 24px;
+        }
+        .card {
+            width: 100%;
+            max-width: 460px;
+            background: #111827;
+            border: 1px solid #1f2937;
+            border-radius: 12px;
+            padding: 24px;
+            box-shadow: 0 10px 30px rgba(0,0,0,.35);
+        }
+        h1 { margin-top: 0; font-size: 1.4rem; }
+        p.meta { color: #94a3b8; font-size: 0.95rem; }
+        label { display: block; margin: 14px 0 6px; font-weight: 600; }
+        input {
+            width: 100%;
+            padding: 10px 12px;
+            border-radius: 8px;
+            border: 1px solid #334155;
+            background: #0b1220;
+            color: #e2e8f0;
+            box-sizing: border-box;
+        }
+        button {
+            margin-top: 18px;
+            width: 100%;
+            padding: 11px 14px;
+            border: 0;
+            border-radius: 8px;
+            background: #22c55e;
+            color: #06220f;
+            font-weight: 700;
+            cursor: pointer;
+        }
+        .errors, .success {
+            margin: 12px 0;
+            padding: 10px 12px;
+            border-radius: 8px;
+            font-size: 0.95rem;
+        }
+        .errors { background: #7f1d1d; color: #fecaca; }
+        .success { background: #14532d; color: #bbf7d0; }
+        ul { margin: 0; padding-left: 20px; }
+    </style>
+</head>
+<body>
+<div class="card">
+    <h1>Dodian registratie</h1>
+    <p class="meta">Maak je account aan om in te loggen op de game-server.</p>
+
+    <?php if ($configMissing): ?>
+        <div class="errors">
+            Config ontbreekt: kopieer <code>config.example.php</code> naar <code>config.php</code> voordat registraties worden opgeslagen.
+        </div>
+    <?php endif; ?>
+
+    <?php if (!empty($errors)): ?>
+        <div class="errors">
+            <ul>
+                <?php foreach ($errors as $error): ?>
+                    <li><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($successMessage !== null): ?>
+        <div class="success"><?= htmlspecialchars($successMessage, ENT_QUOTES, 'UTF-8') ?></div>
+    <?php endif; ?>
+
+    <form method="post" action="">
+        <label for="username">Username</label>
+        <input id="username" name="username" maxlength="12" required value="<?= htmlspecialchars($username, ENT_QUOTES, 'UTF-8') ?>">
+
+        <label for="email">E-mail</label>
+        <input id="email" name="email" type="email" required value="<?= htmlspecialchars($email, ENT_QUOTES, 'UTF-8') ?>">
+
+        <label for="password">Wachtwoord</label>
+        <input id="password" name="password" type="password" minlength="8" required>
+
+        <label for="confirm_password">Herhaal wachtwoord</label>
+        <input id="confirm_password" name="confirm_password" type="password" minlength="8" required>
+
+        <button type="submit">Account aanmaken</button>
+    </form>
+</div>
+</body>
+</html>

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -282,7 +282,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                 $pdo->commit();
 
-                $successMessage = 'Account created! Check your email to activate your account.';
+                $successMessage = 'Account created! Check your email to activate your account. This expires in 2 hours!';
                 $username = '';
                 $email = '';
             }

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -769,6 +769,11 @@ $resetTokenFromQuery = isset($_GET['token']) && is_string($_GET['token']) ? trim
             color: #e2e8f0;
             margin-top: 10px;
         }
+        .btn-link.discord {
+            background: #5865f2;
+            color: #ffffff;
+            margin-top: 10px;
+        }
         .errors, .success, .info {
             margin: 12px 0;
             padding: 10px 12px;
@@ -903,9 +908,9 @@ $resetTokenFromQuery = isset($_GET['token']) && is_string($_GET['token']) ? trim
     <?php if ($page === 'download'): ?>
         <p class="meta">Welcome, <?= htmlspecialchars((string)($_SESSION['username'] ?? 'Player'), ENT_QUOTES, 'UTF-8') ?>. You are signed in.</p>
         <div class="downloads">
-            <a class="btn-link" href="<?= htmlspecialchars($clientJarUrl, ENT_QUOTES, 'UTF-8') ?>">Download game client (.jar)</a>
+            <a class="btn-link" href="<?= htmlspecialchars($clientJarUrl, ENT_QUOTES, 'UTF-8') ?>">Download game client</a>
             <a class="btn-link secondary" href="<?= htmlspecialchars($javaDownloadUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Download Java</a>
-            <a class="btn-link secondary" href="<?= htmlspecialchars($discordUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Join Discord</a>
+            <a class="btn-link discord" href="<?= htmlspecialchars($discordUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Join Discord</a>
             <a class="btn-link secondary" href="?page=change-password">Change password</a>
             <a class="btn-link secondary" href="?logout=1">Sign out</a>
         </div>

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -230,6 +230,7 @@ $infoMessage = null;
 $turnstileSiteKey = $configMissing ? '' : trim((string)($config['turnstile']['site_key'] ?? ''));
 $clientJarUrl = $configMissing ? '#' : trim((string)($config['app']['client_jar_url'] ?? '#'));
 $javaDownloadUrl = $configMissing ? 'https://www.java.com/download/' : trim((string)($config['app']['java_download_url'] ?? 'https://www.java.com/download/'));
+$discordUrl = $configMissing ? 'https://discord.gg/' : trim((string)($config['app']['discord_url'] ?? 'https://discord.gg/'));
 
 $page = isset($_GET['page']) && is_string($_GET['page']) ? strtolower(trim($_GET['page'])) : '';
 $allowedPages = ['login', 'register', 'forgot-password', 'download', 'reset-password', 'activate'];
@@ -829,6 +830,7 @@ $resetTokenFromQuery = isset($_GET['token']) && is_string($_GET['token']) ? trim
         <div class="downloads">
             <a class="btn-link" href="<?= htmlspecialchars($clientJarUrl, ENT_QUOTES, 'UTF-8') ?>">Download game client (.jar)</a>
             <a class="btn-link secondary" href="<?= htmlspecialchars($javaDownloadUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Download Java</a>
+            <a class="btn-link secondary" href="<?= htmlspecialchars($discordUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Join Discord</a>
             <a class="btn-link secondary" href="?logout=1">Sign out</a>
         </div>
     <?php endif; ?>

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -43,7 +43,7 @@ $email = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($configMissing) {
-        $errors[] = 'Server is nog niet geconfigureerd. Kopieer config.example.php naar config.php en vul DB-gegevens in.';
+        $errors[] = 'Server is not configured yet. Copy config.example.php to config.php and add database credentials.';
     }
 
     $username = trim((string)($_POST['username'] ?? ''));
@@ -52,19 +52,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $confirmPassword = (string)($_POST['confirm_password'] ?? '');
 
     if (!preg_match('/^[A-Za-z0-9_]{3,12}$/', $username)) {
-        $errors[] = 'Username moet 3-12 tekens zijn en alleen letters, cijfers of underscore bevatten.';
+        $errors[] = 'Username must be 3-12 characters and contain only letters, numbers, or underscore.';
     }
 
     if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-        $errors[] = 'Voer een geldig e-mailadres in.';
+        $errors[] = 'Enter a valid email address.';
     }
 
     if (strlen($password) < 8) {
-        $errors[] = 'Wachtwoord moet minimaal 8 tekens bevatten.';
+        $errors[] = 'Password must be at least 8 characters long.';
     }
 
     if ($password !== $confirmPassword) {
-        $errors[] = 'Wachtwoorden komen niet overeen.';
+        $errors[] = 'Passwords do not match.';
     }
 
     if (!$configMissing && empty($errors)) {
@@ -74,7 +74,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $stmt = $pdo->prepare('SELECT 1 FROM user WHERE username = :username LIMIT 1');
             $stmt->execute(['username' => $username]);
             if ($stmt->fetch()) {
-                $errors[] = 'Deze username bestaat al.';
+                $errors[] = 'This username already exists.';
             } else {
                 $salt = randomSalt(30);
                 $storedPassword = dodianPasswordHash($password, $salt);
@@ -94,23 +94,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'joindate' => time(),
                 ]);
 
-                $successMessage = 'Account aangemaakt! Je kunt nu inloggen in-game.';
+                $successMessage = 'Account created! You can now log in in-game.';
                 $username = '';
                 $email = '';
             }
         } catch (Throwable $e) {
-            $errors[] = 'Registratie mislukt door een server/database fout.';
+            $errors[] = 'Registration failed due to a server/database error.';
             error_log('Registration error: ' . $e->getMessage());
         }
     }
 }
 ?>
 <!doctype html>
-<html lang="nl">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dodian Account Registratie</title>
+    <title>Dodian Account Registration</title>
     <style>
         :root { color-scheme: dark; }
         body {
@@ -168,12 +168,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </head>
 <body>
 <div class="card">
-    <h1>Dodian registratie</h1>
-    <p class="meta">Maak je account aan om in te loggen op de game-server.</p>
+    <h1>Dodian registration</h1>
+    <p class="meta">Create your account to log in to the game server.</p>
 
     <?php if ($configMissing): ?>
         <div class="errors">
-            Config ontbreekt: kopieer <code>config.example.php</code> naar <code>config.php</code> voordat registraties worden opgeslagen.
+            Config is missing: copy <code>config.example.php</code> to <code>config.php</code> before registrations can be saved.
         </div>
     <?php endif; ?>
 
@@ -198,13 +198,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <label for="email">E-mail</label>
         <input id="email" name="email" type="email" required value="<?= htmlspecialchars($email, ENT_QUOTES, 'UTF-8') ?>">
 
-        <label for="password">Wachtwoord</label>
+        <label for="password">Password</label>
         <input id="password" name="password" type="password" minlength="8" required>
 
-        <label for="confirm_password">Herhaal wachtwoord</label>
+        <label for="confirm_password">Repeat password</label>
         <input id="confirm_password" name="confirm_password" type="password" minlength="8" required>
 
-        <button type="submit">Account aanmaken</button>
+        <button type="submit">Create account</button>
     </form>
 </div>
 </body>

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -228,6 +228,8 @@ $errors = [];
 $successMessage = null;
 $infoMessage = null;
 $turnstileSiteKey = $configMissing ? '' : trim((string)($config['turnstile']['site_key'] ?? ''));
+$clientJarUrl = $configMissing ? '#' : trim((string)($config['app']['client_jar_url'] ?? '#'));
+$javaDownloadUrl = $configMissing ? 'https://www.java.com/download/' : trim((string)($config['app']['java_download_url'] ?? 'https://www.java.com/download/'));
 
 $page = isset($_GET['page']) && is_string($_GET['page']) ? strtolower(trim($_GET['page'])) : '';
 $allowedPages = ['login', 'register', 'forgot-password', 'download', 'reset-password', 'activate'];
@@ -825,9 +827,8 @@ $resetTokenFromQuery = isset($_GET['token']) && is_string($_GET['token']) ? trim
     <?php if ($page === 'download'): ?>
         <p class="meta">Welcome, <?= htmlspecialchars((string)($_SESSION['username'] ?? 'Player'), ENT_QUOTES, 'UTF-8') ?>. You are signed in.</p>
         <div class="downloads">
-            <a class="btn-link" href="#">Download Windows client</a>
-            <a class="btn-link secondary" href="#">Download Mac client</a>
-            <a class="btn-link secondary" href="#">Download Linux client</a>
+            <a class="btn-link" href="<?= htmlspecialchars($clientJarUrl, ENT_QUOTES, 'UTF-8') ?>">Download game client (.jar)</a>
+            <a class="btn-link secondary" href="<?= htmlspecialchars($javaDownloadUrl, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer">Download Java</a>
             <a class="btn-link secondary" href="?logout=1">Sign out</a>
         </div>
     <?php endif; ?>

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -1599,6 +1599,9 @@ if ($page === 'admin-users' && $hasAdminPanelAccess && requireConfiguredOrFail($
             padding: 24px;
             box-shadow: 0 10px 30px rgba(0,0,0,.35);
         }
+        .card.admin-wide {
+            max-width: 980px;
+        }
         h1 { margin-top: 0; font-size: 1.4rem; }
         p.meta { color: #94a3b8; font-size: 0.95rem; }
         label { display: block; margin: 14px 0 6px; font-weight: 600; }
@@ -1672,19 +1675,46 @@ if ($page === 'admin-users' && $hasAdminPanelAccess && requireConfiguredOrFail($
             margin-top: 14px;
             display: grid;
             gap: 10px;
-            max-height: 360px;
+            max-height: 560px;
             overflow-y: auto;
+            padding-right: 4px;
         }
         .admin-user-card {
             border: 1px solid #334155;
-            border-radius: 8px;
-            padding: 10px;
+            border-radius: 10px;
+            padding: 14px;
             background: #0b1220;
+            display: grid;
+            grid-template-columns: minmax(220px, 1fr) minmax(240px, 1fr) 160px;
+            gap: 10px;
+            align-items: end;
         }
         .admin-user-row {
-            font-size: 0.9rem;
-            margin-bottom: 8px;
+            font-size: 0.95rem;
+            margin-bottom: 6px;
             color: #cbd5e1;
+            font-weight: 600;
+        }
+        .admin-role-label {
+            font-size: 0.8rem;
+            color: #94a3b8;
+            margin-bottom: 6px;
+            display: block;
+        }
+        .admin-actions {
+            display: flex;
+            align-items: end;
+        }
+        .admin-actions button {
+            margin-top: 0;
+        }
+        @media (max-width: 860px) {
+            .card.admin-wide {
+                max-width: 100%;
+            }
+            .admin-user-card {
+                grid-template-columns: 1fr;
+            }
         }
         select {
             width: 100%;
@@ -1698,7 +1728,7 @@ if ($page === 'admin-users' && $hasAdminPanelAccess && requireConfiguredOrFail($
     </style>
 </head>
 <body>
-<div class="card">
+<div class="card<?= $page === 'admin-users' ? ' admin-wide' : '' ?>">
     <h1>Dodian account portal</h1>
 
     <?php if ($configMissing): ?>
@@ -1850,24 +1880,35 @@ if ($page === 'admin-users' && $hasAdminPanelAccess && requireConfiguredOrFail($
 
     <?php if ($page === 'admin-users'): ?>
         <p class="meta">User management: only visible for usergroups 6, 10, and 18.</p>
+        <?php if (empty($adminManageableUsers)): ?>
+            <p class="meta">No users found.</p>
+        <?php endif; ?>
         <div class="admin-list">
             <?php foreach ($adminManageableUsers as $userRow): ?>
-                <div class="admin-user-card">
-                    <div class="admin-user-row">#<?= (int)$userRow['userid'] ?> - <?= htmlspecialchars((string)$userRow['username'], ENT_QUOTES, 'UTF-8') ?></div>
-                    <form method="post" action="">
-                        <input type="hidden" name="action" value="admin-update-role">
-                        <input type="hidden" name="user_id" value="<?= (int)$userRow['userid'] ?>">
-                        <label>Role</label>
-                        <select name="role_key" required>
+                <form method="post" action="" class="admin-user-card">
+                    <input type="hidden" name="action" value="admin-update-role">
+                    <input type="hidden" name="user_id" value="<?= (int)$userRow['userid'] ?>">
+
+                    <div>
+                        <div class="admin-user-row">#<?= (int)$userRow['userid'] ?> - <?= htmlspecialchars((string)$userRow['username'], ENT_QUOTES, 'UTF-8') ?></div>
+                        <span class="admin-role-label">Current role: <?= htmlspecialchars((string)(getSupportedWebRoles()[$userRow['role_key']]['label'] ?? ucfirst(str_replace('_', ' ', (string)$userRow['role_key']))), ENT_QUOTES, 'UTF-8') ?></span>
+                    </div>
+
+                    <div>
+                        <label class="admin-role-label" for="role_<?= (int)$userRow['userid'] ?>">Assign role</label>
+                        <select id="role_<?= (int)$userRow['userid'] ?>" name="role_key" required>
                             <?php foreach (getSupportedWebRoles() as $roleKey => $roleDefinition): ?>
                                 <option value="<?= htmlspecialchars((string)$roleKey, ENT_QUOTES, 'UTF-8') ?>" <?= $userRow['role_key'] === $roleKey ? 'selected' : '' ?>>
                                     <?= htmlspecialchars((string)$roleDefinition['label'], ENT_QUOTES, 'UTF-8') ?>
                                 </option>
                             <?php endforeach; ?>
                         </select>
-                        <button type="submit">Save</button>
-                    </form>
-                </div>
+                    </div>
+
+                    <div class="admin-actions">
+                        <button type="submit">Update role</button>
+                    </div>
+                </form>
             <?php endforeach; ?>
         </div>
         <div class="links">

--- a/web-registration-simple/index.php
+++ b/web-registration-simple/index.php
@@ -1366,7 +1366,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if (empty($errors)) {
                     applyWebRoleToAccount($pdo, $userId, $roleKey);
 
-                    $targetLookup = $pdo->prepare('SELECT u.usergroupid, c.unbantime FROM user u INNER JOIN game_characters c ON c.id = u.userid WHERE u.userid = :userid LIMIT 1');
+                    $targetLookup = $pdo->prepare('SELECT u.usergroupid, COALESCE(c.unbantime, 0) AS unbantime FROM user u LEFT JOIN game_characters c ON c.id = u.userid WHERE u.userid = :userid LIMIT 1');
                     $targetLookup->execute(['userid' => $userId]);
                     $targetRow = $targetLookup->fetch();
                     if ($targetRow) {
@@ -1438,9 +1438,9 @@ if ($page === 'admin-users' && canAccessAdminPanel($currentSessionUserGroupId) &
     try {
         $pdo = pdoFromConfig($config);
         $listUsers = $pdo->query(
-            'SELECT u.userid, u.username, u.usergroupid, c.unbantime
+            'SELECT u.userid, u.username, u.usergroupid, COALESCE(c.unbantime, 0) AS unbantime
              FROM user u
-             INNER JOIN game_characters c ON c.id = u.userid
+             LEFT JOIN game_characters c ON c.id = u.userid
              ORDER BY u.userid DESC
              LIMIT 200'
         );


### PR DESCRIPTION
### Motivation
- Prevent the client from repeatedly re-downloading the cache when extraction fails and the client incorrectly records the cache as up-to-date.
- Harden the unzip flow to surface extraction errors instead of swallowing them silently.

### Description
- Change `Unzip.unZipIt` to return a `boolean` success value and use try-with-resources for `ZipInputStream` and `FileOutputStream` so failures propagate reliably.
- Add canonical-path validation to block zip entries that would extract outside the destination folder and correctly handle directory entries during extraction.
- In `CacheDownloader.init` check the return value of `Unzip.unZipIt` and throw an exception on failure so `version.txt` is not written after a broken extraction.
- Use an explicit `IOException` import and return `false` from `unZipIt` when exceptions occur so callers can react deterministically.

### Testing
- Ran `./gradlew :mystic-updatedclient:compileJava` to validate the changes; compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69975b9c5c10832997a2ec8d8b8626b7)